### PR TITLE
feat: Allow multi search API to return bytes or any content type

### DIFF
--- a/typesense/multi_search.go
+++ b/typesense/multi_search.go
@@ -41,7 +41,7 @@ func (m *multiSearch) PerformWithContentType(searchParams *api.MultiSearchParams
 	if err != nil {
 		return nil, err
 	}
-	if response.HTTPResponse == nil {
+	if response.Body == nil {
 		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
 	}
 	return response, nil

--- a/typesense/multi_search.go
+++ b/typesense/multi_search.go
@@ -1,13 +1,17 @@
 package typesense
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 
 	"github.com/typesense/typesense-go/typesense/api"
 )
 
 type MultiSearchInterface interface {
 	Perform(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error)
+	PerformWithContentType(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error)
 }
 
 type multiSearch struct {
@@ -23,4 +27,22 @@ func (m *multiSearch) Perform(searchParams *api.MultiSearchParams, commonSearchP
 		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
 	}
 	return response.JSON200, nil
+}
+
+func (m *multiSearch) PerformWithContentType(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error) {
+	body := api.MultiSearchJSONRequestBody(commonSearchParams)
+	var requestReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	requestReader = bytes.NewReader(buf)
+	response, err := m.apiClient.MultiSearchWithBodyWithResponse(context.Background(), searchParams, contentType, requestReader)
+	if err != nil {
+		return nil, err
+	}
+	if response.HTTPResponse == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response, nil
 }


### PR DESCRIPTION
## Change Summary
- Allow users to request search response in any `content-type`

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
