### PR TITLE
Update comment to indicate created time stored in seconds

### DIFF
--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -87,7 +87,7 @@ components:
         - $ref: '#/components/schemas/CollectionSchema'
         - properties:
             created_at:
-              description: Timestamp of when the collection was created
+              description: Timestamp of when the collection was created (Unix epoch in seconds)
               format: int64
               readOnly: true
               type: integer

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -78,7 +78,7 @@ type CollectionAliasesResponse struct {
 
 // CollectionResponse defines model for CollectionResponse.
 type CollectionResponse struct {
-	// CreatedAt Timestamp of when the collection was created
+	// CreatedAt Timestamp of when the collection was created (Unix epoch in seconds)
 	CreatedAt *int64 `json:"created_at,omitempty"`
 
 	// DefaultSortingField The name of an int32 / float field that determines the order in which the search results are ranked when a sort_by clause is not provided during searching. This field must indicate some kind of popularity.


### PR DESCRIPTION
## Change Summary

Update comment for `CollectionResponse.CreatedAt` to indicate value stored is in Unix epoch time in seconds. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
