### PR TITLE
Swap multi search argument names

### DIFF
--- a/typesense/multi_search.go
+++ b/typesense/multi_search.go
@@ -10,16 +10,16 @@ import (
 )
 
 type MultiSearchInterface interface {
-	Perform(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error)
-	PerformWithContentType(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error)
+	Perform(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error)
+	PerformWithContentType(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error)
 }
 
 type multiSearch struct {
 	apiClient APIClientInterface
 }
 
-func (m *multiSearch) Perform(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error) {
-	response, err := m.apiClient.MultiSearchWithResponse(context.Background(), searchParams, api.MultiSearchJSONRequestBody(commonSearchParams))
+func (m *multiSearch) Perform(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error) {
+	response, err := m.apiClient.MultiSearchWithResponse(context.Background(), commonSearchParams, api.MultiSearchJSONRequestBody(searchParams))
 	if err != nil {
 		return nil, err
 	}
@@ -29,15 +29,15 @@ func (m *multiSearch) Perform(searchParams *api.MultiSearchParams, commonSearchP
 	return response.JSON200, nil
 }
 
-func (m *multiSearch) PerformWithContentType(searchParams *api.MultiSearchParams, commonSearchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error) {
-	body := api.MultiSearchJSONRequestBody(commonSearchParams)
+func (m *multiSearch) PerformWithContentType(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error) {
+	body := api.MultiSearchJSONRequestBody(searchParams)
 	var requestReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	requestReader = bytes.NewReader(buf)
-	response, err := m.apiClient.MultiSearchWithBodyWithResponse(context.Background(), searchParams, contentType, requestReader)
+	response, err := m.apiClient.MultiSearchWithBodyWithResponse(context.Background(), commonSearchParams, contentType, requestReader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Change Summary
The first argument to the `Perform*` functions contains the common parameters, with the second argument containing individual search parameters.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
