### PR TITLE
fix: partial document update with 201 status code

### DIFF
--- a/typesense/api/client_gen.go
+++ b/typesense/api/client_gen.go
@@ -4421,6 +4421,7 @@ type UpdateDocumentResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *map[string]interface{}
+	JSON201      *map[string]interface{}
 	JSON404      *ApiResponse
 }
 
@@ -5823,6 +5824,13 @@ func ParseUpdateDocumentResponse(rsp *http.Response) (*UpdateDocumentResponse, e
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ApiResponse

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -1434,6 +1434,13 @@ paths:
                 description: Can be any key-value pair
                 type: object
           description: The document referenced by the ID was updated
+        201:
+          content:
+            application/json:
+              schema:
+                description: Can be any key-value pair
+                type: object
+          description: The document referenced by the ID was updated
         404:
           content:
             application/json:

--- a/typesense/document.go
+++ b/typesense/document.go
@@ -2,6 +2,7 @@ package typesense
 
 import (
 	"context"
+	"net/http"
 )
 
 type DocumentInterface interface {
@@ -34,10 +35,15 @@ func (d *document) Update(document interface{}) (map[string]interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
-	if response.JSON200 == nil {
+
+	switch response.StatusCode() {
+	case http.StatusOK:
+		return *response.JSON200, nil
+	case http.StatusCreated:
+		return *response.JSON201, nil
+	default:
 		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
 	}
-	return *response.JSON200, nil
 }
 
 func (d *document) Delete() (map[string]interface{}, error) {


### PR DESCRIPTION
## Change Summary
when partial update happens for a document, e.g. below the return is a 201, showned in the logger

```
updatePayload := map[string]interface{}{
	field: value,
}

_, err := r.client.Collection(collection).Document(documentID).Update(updatePayload)
if err != nil {
	fmt.Println(err)
	log.Error().Err(err).
		Interface("dd.trace_id", span.Context().TraceID()).
		Interface("dd.span_id", span.Context().SpanID()).
		Msg("failed to update document")
	return err
}
```

log
```
status: 201 response: {"followers_count":1,"id":"20542911","is_banned":false,"is_live":false,"slug":"danidomi","username":"danidomi","verified":false}
{"level":"error","error":"status: 201 response: {":\"danidomi\",\"username\":\"danidomi\",\"verified\":false}","dd.trace_id":830451322171203481,"dd.span_id":830451322171203481,"time":"2023-12-09T16:49:45Z","message":"failed to update document"}
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
