### PR TITLE
Take context.Context in all functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can also find some examples in [integration tests](https://github.com/typese
 		DefaultSortingField: pointer.String("num_employees"),
 	}
 
-	client.Collections().Create(schema)
+	client.Collections().Create(context.Background(), schema)
 ```
 
 ### Index a document
@@ -86,7 +86,7 @@ You can also find some examples in [integration tests](https://github.com/typese
 		Country:      "USA",
 	}
 
-	client.Collection("companies").Documents().Create(document)
+	client.Collection("companies").Documents().Create(context.Background(), document)
 ```
 
 ### Upserting a document
@@ -104,7 +104,7 @@ You can also find some examples in [integration tests](https://github.com/typese
 		Country:      "USA",
 	}
 
-	client.Collection("companies").Documents().Upsert(newDocument)
+	client.Collection("companies").Documents().Upsert(context.Background(), newDocument)
 ```
 
 ### Search a collection
@@ -117,7 +117,7 @@ You can also find some examples in [integration tests](https://github.com/typese
 		SortBy:   &([]string{"num_employees:desc"}),
 	}
 
-	client.Collection("companies").Documents().Search(searchParameters)
+	client.Collection("companies").Documents().Search(context.Background(), searchParameters)
 ```
 
 for the supporting multiple `QueryBy` params, you can add `,` after each field
@@ -130,13 +130,13 @@ for the supporting multiple `QueryBy` params, you can add `,` after each field
 		SortBy:   &([]string{"num_employees:desc"}),
 	}
 
-	client.Collection("companies").Documents().Search(searchParameters)
+	client.Collection("companies").Documents().Search(context.Background(), searchParameters)
 ```
 
 ### Retrieve a document
 
 ```go
-client.Collection("companies").Document("123").Retrieve()
+client.Collection("companies").Document("123").Retrieve(context.Background())
 ```
 
 ### Update a document
@@ -150,32 +150,32 @@ client.Collection("companies").Document("123").Retrieve()
 		NumEmployees: 5500,
 	}
 
-	client.Collection("companies").Document("123").Update(document)
+	client.Collection("companies").Document("123").Update(context.Background(), document)
 ```
 
 ### Delete an individual document
 
 ```go
-client.Collection("companies").Document("123").Delete()
+client.Collection("companies").Document("123").Delete(context.Background())
 ```
 
 ### Delete a bunch of documents
 
 ```go
 filter := &api.DeleteDocumentsParams{FilterBy: "num_employees:>100", BatchSize: 100}
-client.Collection("companies").Documents().Delete(filter)
+client.Collection("companies").Documents().Delete(context.Background(), filter)
 ```
 
 ### Retrieve a collection
 
 ```go
-client.Collection("companies").Retrieve()
+client.Collection("companies").Retrieve(context.Background())
 ```
 
 ### Export documents from a collection
 
 ```go
-client.Collection("companies").Documents().Export()
+client.Collection("companies").Documents().Export(context.Background())
 ```
 
 ### Import documents into a collection
@@ -203,7 +203,7 @@ Import an array of documents:
 		BatchSize: pointer.Int(40),
 	}
 
-	client.Collection("companies").Documents().Import(documents, params)
+	client.Collection("companies").Documents().Import(context.Background(), documents, params)
 ```
 
 Import a JSONL file:
@@ -216,19 +216,19 @@ Import a JSONL file:
 	importBody, err := os.Open("documents.jsonl")
 	// defer close, error handling ...
 
-	client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 ```
 
 ### List all collections
 
 ```go
-client.Collections().Retrieve()
+client.Collections().Retrieve(context.Background())
 ```
 
 ### Drop a collection
 
 ```go
-client.Collection("companies").Delete()
+client.Collection("companies").Delete(context.Background())
 ```
 
 ### Create an API Key
@@ -241,25 +241,25 @@ client.Collection("companies").Delete()
 		ExpiresAt:   time.Now().AddDate(0, 6, 0).Unix(),
 	}
 
-	client.Keys().Create(keySchema)
+	client.Keys().Create(context.Background(), keySchema)
 ```
 
 ### Retrieve an API Key
 
 ```go
-client.Key(1).Retrieve()
+client.Key(1).Retrieve(context.Background())
 ```
 
 ### List all keys
 
 ```go
-client.Keys().Retrieve()
+client.Keys().Retrieve(context.Background())
 ```
 
 ### Delete API Key
 
 ```go
-client.Key(1).Delete()
+client.Key(1).Delete(context.Background())
 ```
 
 ### Create or update an override
@@ -287,19 +287,19 @@ client.Key(1).Delete()
 		},
 	}
 
-	client.Collection("companies").Overrides().Upsert("customize-apple", override)
+	client.Collection("companies").Overrides().Upsert(context.Background(), "customize-apple", override)
 ```
 
 ### List all overrides
 
 ```go
-client.Collection("companies").Overrides().Retrieve()
+client.Collection("companies").Overrides().Retrieve(context.Background())
 ```
 
 ### Delete an override
 
 ```go
-client.Collection("companies").Override("customize-apple").Delete()
+client.Collection("companies").Override("customize-apple").Delete(context.Background())
 ```
 
 ### Create or Update an alias
@@ -312,19 +312,19 @@ client.Collection("companies").Override("customize-apple").Delete()
 ### Retrieve an alias
 
 ```go
-client.Alias("companies").Retrieve()
+client.Alias("companies").Retrieve(context.Background())
 ```
 
 ### List all aliases
 
 ```go
-client.Aliases().Retrieve()
+client.Aliases().Retrieve(context.Background())
 ```
 
 ### Delete an alias
 
 ```go
-client.Alias("companies").Delete()
+client.Alias("companies").Delete(context.Background())
 ```
 
 ### Create or update a multi-way synonym
@@ -333,7 +333,7 @@ client.Alias("companies").Delete()
 	synonym := &api.SearchSynonymSchema{
 		Synonyms: []string{"blazer", "coat", "jacket"},
 	}
-	client.Collection("products").Synonyms().Upsert("coat-synonyms", synonym)
+	client.Collection("products").Synonyms().Upsert(context.Background(), "coat-synonyms", synonym)
 ```
 
 ### Create or update a one-way synonym
@@ -343,37 +343,37 @@ client.Alias("companies").Delete()
 		Root:     "blazer",
 		Synonyms: []string{"blazer", "coat", "jacket"},
 	}
-	client.Collection("products").Synonyms().Upsert("coat-synonyms", synonym)
+	client.Collection("products").Synonyms().Upsert(context.Background(), "coat-synonyms", synonym)
 ```
 
 ### Retrieve a synonym
 
 ```go
-client.Collection("products").Synonym("coat-synonyms").Retrieve()
+client.Collection("products").Synonym("coat-synonyms").Retrieve(context.Background())
 ```
 
 ### List all synonyms
 
 ```go
-client.Collection("products").Synonyms().Retrieve()
+client.Collection("products").Synonyms().Retrieve(context.Background())
 ```
 
 ### Delete a synonym
 
 ```go
-client.Collection("products").Synonym("coat-synonyms").Delete()
+client.Collection("products").Synonym("coat-synonyms").Delete(context.Background())
 ```
 
 ### Create snapshot (for backups)
 
 ```go
-client.Operations().Snapshot("/tmp/typesense-data-snapshot")
+client.Operations().Snapshot(context.Background(), "/tmp/typesense-data-snapshot")
 ```
 
 ### Re-elect Leader
 
 ```go
-client.Operations().Vote()
+client.Operations().Vote(context.Background())
 ```
 
 ## Contributing

--- a/typesense/alias.go
+++ b/typesense/alias.go
@@ -8,8 +8,8 @@ import (
 
 // AliasInterface is a type for Alias API operations
 type AliasInterface interface {
-	Retrieve() (*api.CollectionAlias, error)
-	Delete() (*api.CollectionAlias, error)
+	Retrieve(ctx context.Context) (*api.CollectionAlias, error)
+	Delete(ctx context.Context) (*api.CollectionAlias, error)
 }
 
 type alias struct {
@@ -17,8 +17,8 @@ type alias struct {
 	name      string
 }
 
-func (a *alias) Retrieve() (*api.CollectionAlias, error) {
-	response, err := a.apiClient.GetAliasWithResponse(context.Background(), a.name)
+func (a *alias) Retrieve(ctx context.Context) (*api.CollectionAlias, error) {
+	response, err := a.apiClient.GetAliasWithResponse(ctx, a.name)
 	if err != nil {
 		return nil, err
 	}
@@ -28,8 +28,8 @@ func (a *alias) Retrieve() (*api.CollectionAlias, error) {
 	return response.JSON200, nil
 }
 
-func (a *alias) Delete() (*api.CollectionAlias, error) {
-	response, err := a.apiClient.DeleteAliasWithResponse(context.Background(), a.name)
+func (a *alias) Delete(ctx context.Context) (*api.CollectionAlias, error) {
+	response, err := a.apiClient.DeleteAliasWithResponse(ctx, a.name)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/alias_test.go
+++ b/typesense/alias_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -27,7 +28,7 @@ func TestCollectionAliasRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Alias("collection_alias").Retrieve()
+	result, err := client.Alias("collection_alias").Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -44,7 +45,7 @@ func TestCollectionAliasRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Alias("collection_alias").Retrieve()
+	_, err := client.Alias("collection_alias").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -64,7 +65,7 @@ func TestCollectionAliasRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) 
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Alias("collection_alias").Retrieve()
+	_, err := client.Alias("collection_alias").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -84,7 +85,7 @@ func TestCollectionAliasDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Alias("collection_alias").Delete()
+	result, err := client.Alias("collection_alias").Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -101,7 +102,7 @@ func TestCollectionAliasDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Alias("collection_alias").Delete()
+	_, err := client.Alias("collection_alias").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -121,6 +122,6 @@ func TestCollectionAliasDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Alias("collection_alias").Delete()
+	_, err := client.Alias("collection_alias").Delete(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/aliases.go
+++ b/typesense/aliases.go
@@ -8,8 +8,8 @@ import (
 
 // AliasesInterface is a type for Aliases API operations
 type AliasesInterface interface {
-	Upsert(aliasName string, aliasSchema *api.CollectionAliasSchema) (*api.CollectionAlias, error)
-	Retrieve() ([]*api.CollectionAlias, error)
+	Upsert(ctx context.Context, aliasName string, aliasSchema *api.CollectionAliasSchema) (*api.CollectionAlias, error)
+	Retrieve(ctx context.Context) ([]*api.CollectionAlias, error)
 }
 
 // aliases is internal implementation of AliasesInterface
@@ -17,8 +17,8 @@ type aliases struct {
 	apiClient APIClientInterface
 }
 
-func (a *aliases) Upsert(aliasName string, aliasSchema *api.CollectionAliasSchema) (*api.CollectionAlias, error) {
-	response, err := a.apiClient.UpsertAliasWithResponse(context.Background(),
+func (a *aliases) Upsert(ctx context.Context, aliasName string, aliasSchema *api.CollectionAliasSchema) (*api.CollectionAlias, error) {
+	response, err := a.apiClient.UpsertAliasWithResponse(ctx,
 		aliasName, api.UpsertAliasJSONRequestBody(*aliasSchema))
 	if err != nil {
 		return nil, err
@@ -29,8 +29,8 @@ func (a *aliases) Upsert(aliasName string, aliasSchema *api.CollectionAliasSchem
 	return response.JSON200, nil
 }
 
-func (a *aliases) Retrieve() ([]*api.CollectionAlias, error) {
-	response, err := a.apiClient.GetAliasesWithResponse(context.Background())
+func (a *aliases) Retrieve(ctx context.Context) ([]*api.CollectionAlias, error) {
+	response, err := a.apiClient.GetAliasesWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/aliases_test.go
+++ b/typesense/aliases_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jinzhu/copier"
@@ -39,7 +41,7 @@ func TestCollectionAliasUpsert(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := &api.CollectionAliasSchema{CollectionName: "companies"}
-	result, err := client.Aliases().Upsert("companies_alias", body)
+	result, err := client.Aliases().Upsert(context.Background(), "companies_alias", body)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -60,7 +62,7 @@ func TestCollectionAliasUpsertOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := &api.CollectionAliasSchema{CollectionName: "companies"}
-	_, err := client.Aliases().Upsert("companies_alias", body)
+	_, err := client.Aliases().Upsert(context.Background(), "companies_alias", body)
 	assert.NotNil(t, err)
 }
 
@@ -84,7 +86,7 @@ func TestCollectionAliasUpsertOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := &api.CollectionAliasSchema{CollectionName: "companies"}
-	_, err := client.Aliases().Upsert("companies_alias", body)
+	_, err := client.Aliases().Upsert(context.Background(), "companies_alias", body)
 	assert.NotNil(t, err)
 }
 
@@ -111,7 +113,7 @@ func TestCollectionAliasesRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Aliases().Retrieve()
+	result, err := client.Aliases().Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -129,7 +131,7 @@ func TestCollectionAliasesRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Aliases().Retrieve()
+	_, err := client.Aliases().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -150,6 +152,6 @@ func TestCollectionAliasesRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Aliases().Retrieve()
+	_, err := client.Aliases().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/collection.go
+++ b/typesense/collection.go
@@ -8,15 +8,15 @@ import (
 
 // CollectionInterface is a type for Collection API operations
 type CollectionInterface interface {
-	Retrieve() (*api.CollectionResponse, error)
-	Delete() (*api.CollectionResponse, error)
+	Retrieve(ctx context.Context) (*api.CollectionResponse, error)
+	Delete(ctx context.Context) (*api.CollectionResponse, error)
 	Documents() DocumentsInterface
 	Document(documentID string) DocumentInterface
 	Overrides() OverridesInterface
 	Override(overrideID string) OverrideInterface
 	Synonyms() SynonymsInterface
 	Synonym(synonymID string) SynonymInterface
-	Update(schema *api.CollectionUpdateSchema) (*api.CollectionUpdateSchema, error)
+	Update(context.Context, *api.CollectionUpdateSchema) (*api.CollectionUpdateSchema, error)
 }
 
 // collection is internal implementation of CollectionInterface
@@ -25,8 +25,8 @@ type collection struct {
 	name      string
 }
 
-func (c *collection) Retrieve() (*api.CollectionResponse, error) {
-	response, err := c.apiClient.GetCollectionWithResponse(context.Background(), c.name)
+func (c *collection) Retrieve(ctx context.Context) (*api.CollectionResponse, error) {
+	response, err := c.apiClient.GetCollectionWithResponse(ctx, c.name)
 	if err != nil {
 		return nil, err
 	}
@@ -36,8 +36,8 @@ func (c *collection) Retrieve() (*api.CollectionResponse, error) {
 	return response.JSON200, nil
 }
 
-func (c *collection) Delete() (*api.CollectionResponse, error) {
-	response, err := c.apiClient.DeleteCollectionWithResponse(context.Background(), c.name)
+func (c *collection) Delete(ctx context.Context) (*api.CollectionResponse, error) {
+	response, err := c.apiClient.DeleteCollectionWithResponse(ctx, c.name)
 	if err != nil {
 		return nil, err
 	}
@@ -71,8 +71,8 @@ func (c *collection) Synonym(synonymID string) SynonymInterface {
 	return &synonym{apiClient: c.apiClient, collectionName: c.name, synonymID: synonymID}
 }
 
-func (c *collection) Update(schema *api.CollectionUpdateSchema) (*api.CollectionUpdateSchema, error) {
-	response, err := c.apiClient.UpdateCollectionWithResponse(context.Background(), c.name,
+func (c *collection) Update(ctx context.Context, schema *api.CollectionUpdateSchema) (*api.CollectionUpdateSchema, error) {
+	response, err := c.apiClient.UpdateCollectionWithResponse(ctx, c.name,
 		api.UpdateCollectionJSONRequestBody(*schema))
 	if err != nil {
 		return nil, err

--- a/typesense/collection_test.go
+++ b/typesense/collection_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -48,7 +49,7 @@ func TestCollectionRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Retrieve()
+	result, err := client.Collection("companies").Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -66,7 +67,7 @@ func TestCollectionRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Retrieve()
+	_, err := client.Collection("companies").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +88,7 @@ func TestCollectionRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Retrieve()
+	_, err := client.Collection("companies").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -107,7 +108,7 @@ func TestCollectionDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Delete()
+	result, err := client.Collection("companies").Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -125,7 +126,7 @@ func TestCollectionDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Delete()
+	_, err := client.Collection("companies").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -146,7 +147,7 @@ func TestCollectionDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Delete()
+	_, err := client.Collection("companies").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -168,7 +169,7 @@ func TestCollectionUpdate(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Update(updateSchema)
+	result, err := client.Collection("companies").Update(context.Background(), updateSchema)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -188,7 +189,7 @@ func TestCollectionUpdateOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Update(updateSchema)
+	_, err := client.Collection("companies").Update(context.Background(), updateSchema)
 	assert.Error(t, err)
 }
 
@@ -211,6 +212,6 @@ func TestCollectionUpdateOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("non_existent").Update(updateSchema)
+	_, err := client.Collection("non_existent").Update(context.Background(), updateSchema)
 	assert.Error(t, err)
 }

--- a/typesense/collections.go
+++ b/typesense/collections.go
@@ -8,8 +8,8 @@ import (
 
 // CollectionsInterface is a type for Collections API operations
 type CollectionsInterface interface {
-	Create(schema *api.CollectionSchema) (*api.CollectionResponse, error)
-	Retrieve() ([]*api.CollectionResponse, error)
+	Create(ctx context.Context, schema *api.CollectionSchema) (*api.CollectionResponse, error)
+	Retrieve(ctx context.Context) ([]*api.CollectionResponse, error)
 }
 
 // collections is internal implementation of CollectionsInterface
@@ -17,8 +17,8 @@ type collections struct {
 	apiClient APIClientInterface
 }
 
-func (c *collections) Create(schema *api.CollectionSchema) (*api.CollectionResponse, error) {
-	response, err := c.apiClient.CreateCollectionWithResponse(context.Background(),
+func (c *collections) Create(ctx context.Context, schema *api.CollectionSchema) (*api.CollectionResponse, error) {
+	response, err := c.apiClient.CreateCollectionWithResponse(ctx,
 		api.CreateCollectionJSONRequestBody(*schema))
 	if err != nil {
 		return nil, err
@@ -29,8 +29,8 @@ func (c *collections) Create(schema *api.CollectionSchema) (*api.CollectionRespo
 	return response.JSON201, nil
 }
 
-func (c *collections) Retrieve() ([]*api.CollectionResponse, error) {
-	response, err := c.apiClient.GetCollectionsWithResponse(context.Background())
+func (c *collections) Retrieve(ctx context.Context) ([]*api.CollectionResponse, error) {
+	response, err := c.apiClient.GetCollectionsWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/collections_test.go
+++ b/typesense/collections_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -68,7 +69,7 @@ func TestCollectionCreate(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collections().Create(newSchema)
+	result, err := client.Collections().Create(context.Background(), newSchema)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -88,7 +89,7 @@ func TestCollectionCreateOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collections().Create(newSchema)
+	_, err := client.Collections().Create(context.Background(), newSchema)
 	assert.Error(t, err)
 }
 
@@ -111,7 +112,7 @@ func TestCollectionCreateOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collections().Create(newSchema)
+	_, err := client.Collections().Create(context.Background(), newSchema)
 	assert.Error(t, err)
 }
 
@@ -136,7 +137,7 @@ func TestCollectionsRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collections().Retrieve()
+	result, err := client.Collections().Retrieve(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -153,7 +154,7 @@ func TestCollectionsRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collections().Retrieve()
+	_, err := client.Collections().Retrieve(context.Background())
 	assert.Error(t, err)
 }
 
@@ -173,6 +174,6 @@ func TestCollectionsRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collections().Retrieve()
+	_, err := client.Collections().Retrieve(context.Background())
 	assert.Error(t, err)
 }

--- a/typesense/document.go
+++ b/typesense/document.go
@@ -5,9 +5,9 @@ import (
 )
 
 type DocumentInterface interface {
-	Retrieve() (map[string]interface{}, error)
-	Update(document interface{}) (map[string]interface{}, error)
-	Delete() (map[string]interface{}, error)
+	Retrieve(ctx context.Context) (map[string]interface{}, error)
+	Update(ctx context.Context, document interface{}) (map[string]interface{}, error)
+	Delete(ctx context.Context) (map[string]interface{}, error)
 }
 
 type document struct {
@@ -16,8 +16,8 @@ type document struct {
 	documentID     string
 }
 
-func (d *document) Retrieve() (map[string]interface{}, error) {
-	response, err := d.apiClient.GetDocumentWithResponse(context.Background(),
+func (d *document) Retrieve(ctx context.Context) (map[string]interface{}, error) {
+	response, err := d.apiClient.GetDocumentWithResponse(ctx,
 		d.collectionName, d.documentID)
 	if err != nil {
 		return nil, err
@@ -28,8 +28,8 @@ func (d *document) Retrieve() (map[string]interface{}, error) {
 	return *response.JSON200, nil
 }
 
-func (d *document) Update(document interface{}) (map[string]interface{}, error) {
-	response, err := d.apiClient.UpdateDocumentWithResponse(context.Background(),
+func (d *document) Update(ctx context.Context, document interface{}) (map[string]interface{}, error) {
+	response, err := d.apiClient.UpdateDocumentWithResponse(ctx,
 		d.collectionName, d.documentID, document)
 	if err != nil {
 		return nil, err
@@ -40,8 +40,8 @@ func (d *document) Update(document interface{}) (map[string]interface{}, error) 
 	return *response.JSON200, nil
 }
 
-func (d *document) Delete() (map[string]interface{}, error) {
-	response, err := d.apiClient.DeleteDocumentWithResponse(context.Background(),
+func (d *document) Delete(ctx context.Context) (map[string]interface{}, error) {
+	response, err := d.apiClient.DeleteDocumentWithResponse(ctx,
 		d.collectionName, d.documentID)
 	if err != nil {
 		return nil, err

--- a/typesense/document_test.go
+++ b/typesense/document_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -27,7 +28,7 @@ func TestDocumentRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Document("123").Retrieve()
+	result, err := client.Collection("companies").Document("123").Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -44,7 +45,7 @@ func TestDocumentRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Document("123").Retrieve()
+	_, err := client.Collection("companies").Document("123").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -64,7 +65,7 @@ func TestDocumentRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Document("123").Retrieve()
+	_, err := client.Collection("companies").Document("123").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +88,7 @@ func TestDocumentUpdate(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	document := createNewDocument()
-	result, err := client.Collection("companies").Document("123").Update(document)
+	result, err := client.Collection("companies").Document("123").Update(context.Background(), document)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -108,7 +109,7 @@ func TestDocumentUpdateOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	document := createNewDocument()
-	_, err := client.Collection("companies").Document("123").Update(document)
+	_, err := client.Collection("companies").Document("123").Update(context.Background(), document)
 	assert.NotNil(t, err)
 }
 
@@ -132,7 +133,7 @@ func TestDocumentUpdateOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	document := createNewDocument()
-	_, err := client.Collection("companies").Document("123").Update(document)
+	_, err := client.Collection("companies").Document("123").Update(context.Background(), document)
 	assert.NotNil(t, err)
 }
 
@@ -152,7 +153,7 @@ func TestDocumentDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Document("123").Delete()
+	result, err := client.Collection("companies").Document("123").Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -169,7 +170,7 @@ func TestDocumentDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Document("123").Delete()
+	_, err := client.Collection("companies").Document("123").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -189,6 +190,6 @@ func TestDocumentDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Document("123").Delete()
+	_, err := client.Collection("companies").Document("123").Delete(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/documents.go
+++ b/typesense/documents.go
@@ -22,24 +22,24 @@ const (
 // DocumentsInterface is a type for Documents API operations
 type DocumentsInterface interface {
 	// Create returns indexed document
-	Create(document interface{}) (map[string]interface{}, error)
+	Create(ctx context.Context, document interface{}) (map[string]interface{}, error)
 	// Update updates documents matching the filter_by condition
-	Update(updateFields interface{}, params *api.UpdateDocumentsParams) (int, error)
+	Update(ctx context.Context, updateFields interface{}, params *api.UpdateDocumentsParams) (int, error)
 	// Upsert returns indexed/updated document
-	Upsert(document interface{}) (map[string]interface{}, error)
+	Upsert(context.Context, interface{}) (map[string]interface{}, error)
 	// Delete returns number of deleted documents
-	Delete(filter *api.DeleteDocumentsParams) (int, error)
+	Delete(ctx context.Context, filter *api.DeleteDocumentsParams) (int, error)
 	// Search performs document search in collection
-	Search(params *api.SearchCollectionParams) (*api.SearchResult, error)
+	Search(ctx context.Context, params *api.SearchCollectionParams) (*api.SearchResult, error)
 	// Export returns all documents from index in jsonl format
-	Export() (io.ReadCloser, error)
+	Export(ctx context.Context) (io.ReadCloser, error)
 	// Import returns json array. Each item of the response indicates
 	// the result of each document present in the request body (in the same order).
-	Import(documents []interface{}, params *api.ImportDocumentsParams) ([]*api.ImportDocumentResponse, error)
+	Import(ctx context.Context, documents []interface{}, params *api.ImportDocumentsParams) ([]*api.ImportDocumentResponse, error)
 	// ImportJsonl accepts documents and returns result in jsonl format. Each line of the
 	// response indicates the result of each document present in the
 	// request body (in the same order).
-	ImportJsonl(body io.Reader, params *api.ImportDocumentsParams) (io.ReadCloser, error)
+	ImportJsonl(ctx context.Context, body io.Reader, params *api.ImportDocumentsParams) (io.ReadCloser, error)
 }
 
 // documents is internal implementation of DocumentsInterface
@@ -48,8 +48,8 @@ type documents struct {
 	collectionName string
 }
 
-func (d *documents) indexDocument(document interface{}, params *api.IndexDocumentParams) (map[string]interface{}, error) {
-	response, err := d.apiClient.IndexDocumentWithResponse(context.Background(),
+func (d *documents) indexDocument(ctx context.Context, document interface{}, params *api.IndexDocumentParams) (map[string]interface{}, error) {
+	response, err := d.apiClient.IndexDocumentWithResponse(ctx,
 		d.collectionName, params, document)
 	if err != nil {
 		return nil, err
@@ -60,12 +60,12 @@ func (d *documents) indexDocument(document interface{}, params *api.IndexDocumen
 	return *response.JSON201, nil
 }
 
-func (d *documents) Create(document interface{}) (map[string]interface{}, error) {
-	return d.indexDocument(document, &api.IndexDocumentParams{})
+func (d *documents) Create(ctx context.Context, document interface{}) (map[string]interface{}, error) {
+	return d.indexDocument(ctx, document, &api.IndexDocumentParams{})
 }
 
-func (d *documents) Update(updateFields interface{}, params *api.UpdateDocumentsParams) (int, error) {
-	response, err := d.apiClient.UpdateDocumentsWithResponse(context.Background(),
+func (d *documents) Update(ctx context.Context, updateFields interface{}, params *api.UpdateDocumentsParams) (int, error) {
+	response, err := d.apiClient.UpdateDocumentsWithResponse(ctx,
 		d.collectionName, params, updateFields)
 	if err != nil {
 		return 0, err
@@ -76,12 +76,12 @@ func (d *documents) Update(updateFields interface{}, params *api.UpdateDocuments
 	return response.JSON200.NumUpdated, nil
 }
 
-func (d *documents) Upsert(document interface{}) (map[string]interface{}, error) {
-	return d.indexDocument(document, &api.IndexDocumentParams{Action: &upsertAction})
+func (d *documents) Upsert(ctx context.Context, document interface{}) (map[string]interface{}, error) {
+	return d.indexDocument(ctx, document, &api.IndexDocumentParams{Action: &upsertAction})
 }
 
-func (d *documents) Delete(filter *api.DeleteDocumentsParams) (int, error) {
-	response, err := d.apiClient.DeleteDocumentsWithResponse(context.Background(),
+func (d *documents) Delete(ctx context.Context, filter *api.DeleteDocumentsParams) (int, error) {
+	response, err := d.apiClient.DeleteDocumentsWithResponse(ctx,
 		d.collectionName, filter)
 	if err != nil {
 		return 0, err
@@ -92,8 +92,8 @@ func (d *documents) Delete(filter *api.DeleteDocumentsParams) (int, error) {
 	return response.JSON200.NumDeleted, nil
 }
 
-func (d *documents) Search(params *api.SearchCollectionParams) (*api.SearchResult, error) {
-	response, err := d.apiClient.SearchCollectionWithResponse(context.Background(),
+func (d *documents) Search(ctx context.Context, params *api.SearchCollectionParams) (*api.SearchResult, error) {
+	response, err := d.apiClient.SearchCollectionWithResponse(ctx,
 		d.collectionName, params)
 	if err != nil {
 		return nil, err
@@ -104,8 +104,8 @@ func (d *documents) Search(params *api.SearchCollectionParams) (*api.SearchResul
 	return response.JSON200, nil
 }
 
-func (d *documents) Export() (io.ReadCloser, error) {
-	response, err := d.apiClient.ExportDocuments(context.Background(), d.collectionName, &api.ExportDocumentsParams{})
+func (d *documents) Export(ctx context.Context) (io.ReadCloser, error) {
+	response, err := d.apiClient.ExportDocuments(ctx, d.collectionName, &api.ExportDocumentsParams{})
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func initImportParams(params *api.ImportDocumentsParams) {
 	}
 }
 
-func (d *documents) Import(documents []interface{}, params *api.ImportDocumentsParams) ([]*api.ImportDocumentResponse, error) {
+func (d *documents) Import(ctx context.Context, documents []interface{}, params *api.ImportDocumentsParams) ([]*api.ImportDocumentResponse, error) {
 	if len(documents) == 0 {
 		return nil, errors.New("documents list is empty")
 	}
@@ -141,7 +141,7 @@ func (d *documents) Import(documents []interface{}, params *api.ImportDocumentsP
 		}
 	}
 
-	response, err := d.ImportJsonl(&buf, params)
+	response, err := d.ImportJsonl(ctx, &buf, params)
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +159,9 @@ func (d *documents) Import(documents []interface{}, params *api.ImportDocumentsP
 	return result, nil
 }
 
-func (d *documents) ImportJsonl(body io.Reader, params *api.ImportDocumentsParams) (io.ReadCloser, error) {
+func (d *documents) ImportJsonl(ctx context.Context, body io.Reader, params *api.ImportDocumentsParams) (io.ReadCloser, error) {
 	initImportParams(params)
-	response, err := d.apiClient.ImportDocumentsWithBody(context.Background(),
+	response, err := d.apiClient.ImportDocumentsWithBody(ctx,
 		d.collectionName, params, "application/octet-stream", body)
 	if err != nil {
 		return nil, err

--- a/typesense/documents_test.go
+++ b/typesense/documents_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -63,7 +64,7 @@ func TestDocumentCreate(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	document := createNewDocument()
-	result, err := client.Collection("companies").Documents().Create(document)
+	result, err := client.Collection("companies").Documents().Create(context.Background(), document)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -84,7 +85,7 @@ func TestDocumentCreateOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Create(newDocument)
+	_, err := client.Collection("companies").Documents().Create(context.Background(), newDocument)
 	assert.NotNil(t, err)
 }
 
@@ -108,7 +109,7 @@ func TestDocumentCreateOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Create(newDocument)
+	_, err := client.Collection("companies").Documents().Create(context.Background(), newDocument)
 	assert.NotNil(t, err)
 }
 
@@ -131,7 +132,7 @@ func TestDocumentUpsert(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Documents().Upsert(newDocument)
+	result, err := client.Collection("companies").Documents().Upsert(context.Background(), newDocument)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -152,7 +153,7 @@ func TestDocumentUpsertOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Upsert(newDocument)
+	_, err := client.Collection("companies").Documents().Upsert(context.Background(), newDocument)
 	assert.NotNil(t, err)
 }
 
@@ -176,7 +177,7 @@ func TestDocumentUpsertOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Upsert(newDocument)
+	_, err := client.Collection("companies").Documents().Upsert(context.Background(), newDocument)
 	assert.NotNil(t, err)
 }
 
@@ -205,7 +206,7 @@ func TestDocumentsUpdate(t *testing.T) {
 	client := NewClient(WithAPIClient(mockAPIClient))
 
 	params := &api.UpdateDocumentsParams{FilterBy: pointer.String("num_employees:>100")}
-	result, err := client.Collection("companies").Documents().Update(updateFields, params)
+	result, err := client.Collection("companies").Documents().Update(context.Background(), updateFields, params)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 27, result)
@@ -230,7 +231,7 @@ func TestDocumentsDelete(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	filter := &api.DeleteDocumentsParams{FilterBy: pointer.String("num_employees:>100"), BatchSize: pointer.Int(100)}
-	result, err := client.Collection("companies").Documents().Delete(filter)
+	result, err := client.Collection("companies").Documents().Delete(context.Background(), filter)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 27, result)
@@ -249,7 +250,7 @@ func TestDocumentsDeleteOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	filter := &api.DeleteDocumentsParams{FilterBy: pointer.String("num_employees:>100"), BatchSize: pointer.Int(100)}
-	_, err := client.Collection("companies").Documents().Delete(filter)
+	_, err := client.Collection("companies").Documents().Delete(context.Background(), filter)
 	assert.NotNil(t, err)
 }
 
@@ -271,7 +272,7 @@ func TestDocumentsDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	filter := &api.DeleteDocumentsParams{FilterBy: pointer.String("num_employees:>100"), BatchSize: pointer.Int(100)}
-	_, err := client.Collection("companies").Documents().Delete(filter)
+	_, err := client.Collection("companies").Documents().Delete(context.Background(), filter)
 	assert.NotNil(t, err)
 }
 
@@ -297,7 +298,7 @@ func TestDocumentsExport(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Documents().Export()
+	result, err := client.Collection("companies").Documents().Export(context.Background())
 	assert.Nil(t, err)
 
 	resultBytes, err := ioutil.ReadAll(result)
@@ -316,7 +317,7 @@ func TestDocumentsExportOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Export()
+	_, err := client.Collection("companies").Documents().Export(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -334,6 +335,6 @@ func TestDocumentsExportOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Documents().Export()
+	_, err := client.Collection("companies").Documents().Export(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/health.go
+++ b/typesense/health.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-func (c *Client) Health(timeout time.Duration) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func (c *Client) Health(ctx context.Context, timeout time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	response, err := c.apiClient.HealthWithResponse(ctx)
 	if err != nil {

--- a/typesense/health_test.go
+++ b/typesense/health_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -36,7 +37,7 @@ func TestHealthStatus(t *testing.T) {
 			Times(1)
 
 		client := NewClient(WithAPIClient(mockAPIClient))
-		result, err := client.Health(2 * time.Second)
+		result, err := client.Health(context.Background(), 2*time.Second)
 		assert.NoError(t, err)
 		assert.Conditionf(t, func() bool {
 			return result == tt.ok
@@ -55,7 +56,7 @@ func TestHealthStatusOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Health(2 * time.Second)
+	result, err := client.Health(context.Background(), 2*time.Second)
 	assert.Error(t, err)
 	assert.False(t, result)
 }
@@ -76,7 +77,7 @@ func TestHealthStatusOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Health(2 * time.Second)
+	result, err := client.Health(context.Background(), 2*time.Second)
 	assert.Error(t, err)
 	assert.False(t, result)
 }

--- a/typesense/import_test.go
+++ b/typesense/import_test.go
@@ -2,6 +2,7 @@ package typesense
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -77,7 +78,7 @@ func TestDocumentsImportWithOneDocument(t *testing.T) {
 		Action:    pointer.String("create"),
 		BatchSize: pointer.Int(40),
 	}
-	result, err := client.Collection("companies").Documents().Import(documents, params)
+	result, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -94,7 +95,7 @@ func TestDocumentsImportWithEmptyListReturnsError(t *testing.T) {
 		BatchSize: pointer.Int(40),
 	}
 	documents := []interface{}{}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.NotNil(t, err)
 }
 
@@ -127,7 +128,7 @@ func TestDocumentsImportWithOneDocumentAndInvalidResultJsonReturnsError(t *testi
 		Action:    pointer.String("create"),
 		BatchSize: pointer.Int(40),
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.NotNil(t, err)
 }
 
@@ -144,7 +145,7 @@ func TestDocumentsImportWithInvalidInputDataReturnsError(t *testing.T) {
 	documents := []interface{}{
 		func() {},
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.NotNil(t, err)
 }
 
@@ -167,7 +168,7 @@ func TestDocumentsImportOnApiClientErrorReturnsError(t *testing.T) {
 	documents := []interface{}{
 		createNewDocument(),
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.NotNil(t, err)
 }
 
@@ -193,7 +194,7 @@ func TestDocumentsImportOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 	documents := []interface{}{
 		createNewDocument(),
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.NotNil(t, err)
 }
 
@@ -232,7 +233,7 @@ func TestDocumentsImportWithTwoDocuments(t *testing.T) {
 		Action:    pointer.String("create"),
 		BatchSize: pointer.Int(40),
 	}
-	result, err := client.Collection("companies").Documents().Import(documents, params)
+	result, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -264,7 +265,7 @@ func TestDocumentsImportWithActionOnly(t *testing.T) {
 	params := &api.ImportDocumentsParams{
 		Action: pointer.String("create"),
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.Nil(t, err)
 }
 
@@ -294,7 +295,7 @@ func TestDocumentsImportWithBatchSizeOnly(t *testing.T) {
 	params := &api.ImportDocumentsParams{
 		BatchSize: pointer.Int(10),
 	}
-	_, err := client.Collection("companies").Documents().Import(documents, params)
+	_, err := client.Collection("companies").Documents().Import(context.Background(), documents, params)
 	assert.Nil(t, err)
 }
 
@@ -325,7 +326,7 @@ func TestDocumentsImportJsonl(t *testing.T) {
 		BatchSize: pointer.Int(40),
 	}
 	importBody := createDocumentStream()
-	result, err := client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	result, err := client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 	assert.Nil(t, err)
 
 	resultBytes, err := ioutil.ReadAll(result)
@@ -350,7 +351,7 @@ func TestDocumentsImportJsonlOnApiClientErrorReturnsError(t *testing.T) {
 		BatchSize: pointer.Int(40),
 	}
 	importBody := createDocumentStream()
-	_, err := client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	_, err := client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 	assert.NotNil(t, err)
 }
 
@@ -374,7 +375,7 @@ func TestDocumentsImportJsonlOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		BatchSize: pointer.Int(40),
 	}
 	importBody := createDocumentStream()
-	_, err := client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	_, err := client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 	assert.NotNil(t, err)
 }
 
@@ -402,7 +403,7 @@ func TestDocumentsImportJsonlWithActionOnly(t *testing.T) {
 		Action: pointer.String("create"),
 	}
 	importBody := createDocumentStream()
-	_, err := client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	_, err := client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 	assert.Nil(t, err)
 }
 
@@ -430,6 +431,6 @@ func TestDocumentsImportJsonlWithBatchSizeOnly(t *testing.T) {
 		BatchSize: pointer.Int(10),
 	}
 	importBody := createDocumentStream()
-	_, err := client.Collection("companies").Documents().ImportJsonl(importBody, params)
+	_, err := client.Collection("companies").Documents().ImportJsonl(context.Background(), importBody, params)
 	assert.Nil(t, err)
 }

--- a/typesense/key.go
+++ b/typesense/key.go
@@ -7,8 +7,8 @@ import (
 )
 
 type KeyInterface interface {
-	Retrieve() (*api.ApiKey, error)
-	Delete() (*api.ApiKey, error)
+	Retrieve(ctx context.Context) (*api.ApiKey, error)
+	Delete(ctx context.Context) (*api.ApiKey, error)
 }
 
 type key struct {
@@ -16,8 +16,8 @@ type key struct {
 	keyID     int64
 }
 
-func (k *key) Retrieve() (*api.ApiKey, error) {
-	response, err := k.apiClient.GetKeyWithResponse(context.Background(), k.keyID)
+func (k *key) Retrieve(ctx context.Context) (*api.ApiKey, error) {
+	response, err := k.apiClient.GetKeyWithResponse(ctx, k.keyID)
 	if err != nil {
 		return nil, err
 	}
@@ -27,8 +27,8 @@ func (k *key) Retrieve() (*api.ApiKey, error) {
 	return response.JSON200, nil
 }
 
-func (k *key) Delete() (*api.ApiKey, error) {
-	response, err := k.apiClient.DeleteKeyWithResponse(context.Background(), k.keyID)
+func (k *key) Delete(ctx context.Context) (*api.ApiKey, error) {
+	response, err := k.apiClient.DeleteKeyWithResponse(ctx, k.keyID)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/key_test.go
+++ b/typesense/key_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +30,7 @@ func TestKeyRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Key(1).Retrieve()
+	result, err := client.Key(1).Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -46,7 +48,7 @@ func TestKeyRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Key(1).Retrieve()
+	_, err := client.Key(1).Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -67,7 +69,7 @@ func TestKeyRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Key(1).Retrieve()
+	_, err := client.Key(1).Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +89,7 @@ func TestKeyDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Key(1).Delete()
+	result, err := client.Key(1).Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -105,7 +107,7 @@ func TestKeyDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Key(1).Delete()
+	_, err := client.Key(1).Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -126,6 +128,6 @@ func TestKeyDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Key(1).Delete()
+	_, err := client.Key(1).Delete(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/keys.go
+++ b/typesense/keys.go
@@ -12,8 +12,8 @@ import (
 )
 
 type KeysInterface interface {
-	Create(key *api.ApiKeySchema) (*api.ApiKey, error)
-	Retrieve() ([]*api.ApiKey, error)
+	Create(context.Context, *api.ApiKeySchema) (*api.ApiKey, error)
+	Retrieve(context.Context) ([]*api.ApiKey, error)
 	GenerateScopedSearchKey(searchKey string, params map[string]interface{}) (string, error)
 }
 
@@ -21,8 +21,8 @@ type keys struct {
 	apiClient APIClientInterface
 }
 
-func (k *keys) Create(key *api.ApiKeySchema) (*api.ApiKey, error) {
-	response, err := k.apiClient.CreateKeyWithResponse(context.Background(),
+func (k *keys) Create(ctx context.Context, key *api.ApiKeySchema) (*api.ApiKey, error) {
+	response, err := k.apiClient.CreateKeyWithResponse(ctx,
 		api.CreateKeyJSONRequestBody(*key))
 	if err != nil {
 		return nil, err
@@ -33,8 +33,8 @@ func (k *keys) Create(key *api.ApiKeySchema) (*api.ApiKey, error) {
 	return response.JSON201, nil
 }
 
-func (k *keys) Retrieve() ([]*api.ApiKey, error) {
-	response, err := k.apiClient.GetKeysWithResponse(context.Background())
+func (k *keys) Retrieve(ctx context.Context) ([]*api.ApiKey, error) {
+	response, err := k.apiClient.GetKeysWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/keys_test.go
+++ b/typesense/keys_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -51,7 +52,7 @@ func TestKeyCreate(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Keys().Create(newKey)
+	result, err := client.Keys().Create(context.Background(), newKey)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -71,7 +72,7 @@ func TestKeyCreateOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Keys().Create(newKey)
+	_, err := client.Keys().Create(context.Background(), newKey)
 	assert.NotNil(t, err)
 }
 
@@ -94,7 +95,7 @@ func TestKeyCreateOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Keys().Create(newKey)
+	_, err := client.Keys().Create(context.Background(), newKey)
 	assert.NotNil(t, err)
 }
 
@@ -121,7 +122,7 @@ func TestKeysRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Keys().Retrieve()
+	result, err := client.Keys().Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -138,7 +139,7 @@ func TestKeysRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Keys().Retrieve()
+	_, err := client.Keys().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -158,7 +159,7 @@ func TestKeysRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Keys().Retrieve()
+	_, err := client.Keys().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 

--- a/typesense/multi_search.go
+++ b/typesense/multi_search.go
@@ -10,16 +10,16 @@ import (
 )
 
 type MultiSearchInterface interface {
-	Perform(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error)
-	PerformWithContentType(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error)
+	Perform(ctx context.Context, commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error)
+	PerformWithContentType(ctx context.Context, commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error)
 }
 
 type multiSearch struct {
 	apiClient APIClientInterface
 }
 
-func (m *multiSearch) Perform(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error) {
-	response, err := m.apiClient.MultiSearchWithResponse(context.Background(), commonSearchParams, api.MultiSearchJSONRequestBody(searchParams))
+func (m *multiSearch) Perform(ctx context.Context, commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter) (*api.MultiSearchResult, error) {
+	response, err := m.apiClient.MultiSearchWithResponse(ctx, commonSearchParams, api.MultiSearchJSONRequestBody(searchParams))
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func (m *multiSearch) Perform(commonSearchParams *api.MultiSearchParams, searchP
 	return response.JSON200, nil
 }
 
-func (m *multiSearch) PerformWithContentType(commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error) {
+func (m *multiSearch) PerformWithContentType(ctx context.Context, commonSearchParams *api.MultiSearchParams, searchParams api.MultiSearchSearchesParameter, contentType string) (*api.MultiSearchResponse, error) {
 	body := api.MultiSearchJSONRequestBody(searchParams)
 	var requestReader io.Reader
 	buf, err := json.Marshal(body)
@@ -37,7 +37,7 @@ func (m *multiSearch) PerformWithContentType(commonSearchParams *api.MultiSearch
 		return nil, err
 	}
 	requestReader = bytes.NewReader(buf)
-	response, err := m.apiClient.MultiSearchWithBodyWithResponse(context.Background(), commonSearchParams, contentType, requestReader)
+	response, err := m.apiClient.MultiSearchWithBodyWithResponse(ctx, commonSearchParams, contentType, requestReader)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/multi_search_test.go
+++ b/typesense/multi_search_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -224,7 +225,7 @@ func TestMultiSearch(t *testing.T) {
 		client := NewClient(WithAPIClient(mockAPIClient))
 		params := newMultiSearchParams()
 		body := newMultiSearchBodyParams()
-		result, err := client.MultiSearch.Perform(params, body)
+		result, err := client.MultiSearch.Perform(context.Background(), params, body)
 
 		assert.Nil(t, err)
 		assert.Equal(t, expectedResult, result)
@@ -247,7 +248,7 @@ func TestMultiSearch(t *testing.T) {
 		client := NewClient(WithAPIClient(mockAPIClient))
 		params := newMultiSearchParams()
 		reqBody := newMultiSearchBodyParams()
-		result, err := client.MultiSearch.PerformWithContentType(params, reqBody, expectedContentType)
+		result, err := client.MultiSearch.PerformWithContentType(context.Background(), params, reqBody, expectedContentType)
 
 		assert.Nil(t, err)
 		assert.Equal(t, expectedResponseBytes, result.Body)
@@ -272,7 +273,7 @@ func TestMultiSearchOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	params := newMultiSearchParams()
-	_, err := client.MultiSearch.Perform(params, newMultiSearchBodyParams())
+	_, err := client.MultiSearch.Perform(context.Background(), params, newMultiSearchBodyParams())
 	assert.NotNil(t, err)
 }
 
@@ -289,6 +290,6 @@ func TestMultiSearchOnApiClientError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	params := newMultiSearchParams()
-	_, err := client.MultiSearch.Perform(params, newMultiSearchBodyParams())
+	_, err := client.MultiSearch.Perform(context.Background(), params, newMultiSearchBodyParams())
 	assert.NotNil(t, err)
 }

--- a/typesense/operations.go
+++ b/typesense/operations.go
@@ -7,16 +7,16 @@ import (
 )
 
 type OperationsInterface interface {
-	Snapshot(snapshotPath string) (bool, error)
-	Vote() (bool, error)
+	Snapshot(ctx context.Context, snapshotPath string) (bool, error)
+	Vote(ctx context.Context) (bool, error)
 }
 
 type operations struct {
 	apiClient APIClientInterface
 }
 
-func (o *operations) Snapshot(snapshotPath string) (bool, error) {
-	response, err := o.apiClient.TakeSnapshotWithResponse(context.Background(),
+func (o *operations) Snapshot(ctx context.Context, snapshotPath string) (bool, error) {
+	response, err := o.apiClient.TakeSnapshotWithResponse(ctx,
 		&api.TakeSnapshotParams{SnapshotPath: snapshotPath})
 	if err != nil {
 		return false, err
@@ -27,8 +27,8 @@ func (o *operations) Snapshot(snapshotPath string) (bool, error) {
 	return response.JSON201.Success, nil
 }
 
-func (o *operations) Vote() (bool, error) {
-	response, err := o.apiClient.VoteWithResponse(context.Background())
+func (o *operations) Vote(ctx context.Context) (bool, error) {
+	response, err := o.apiClient.VoteWithResponse(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/typesense/operations_test.go
+++ b/typesense/operations_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -39,7 +40,7 @@ func TestSnapshot(t *testing.T) {
 			Times(1)
 
 		client := NewClient(WithAPIClient(mockAPIClient))
-		result, err := client.Operations().Snapshot(snapshotPath)
+		result, err := client.Operations().Snapshot(context.Background(), snapshotPath)
 		assert.NoError(t, err)
 		assert.Conditionf(t, func() bool {
 			return result == tt.ok
@@ -60,7 +61,7 @@ func TestSnapshotOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Operations().Snapshot(snapshotPath)
+	result, err := client.Operations().Snapshot(context.Background(), snapshotPath)
 	assert.Error(t, err)
 	assert.False(t, result)
 }
@@ -83,7 +84,7 @@ func TestSnapshotOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Operations().Snapshot(snapshotPath)
+	result, err := client.Operations().Snapshot(context.Background(), snapshotPath)
 	assert.Error(t, err)
 	assert.False(t, result)
 }
@@ -113,7 +114,7 @@ func TestVote(t *testing.T) {
 			Times(1)
 
 		client := NewClient(WithAPIClient(mockAPIClient))
-		result, err := client.Operations().Vote()
+		result, err := client.Operations().Vote(context.Background())
 		assert.NoError(t, err)
 		assert.Conditionf(t, func() bool {
 			return result == tt.ok
@@ -133,7 +134,7 @@ func TestVoteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Operations().Vote()
+	result, err := client.Operations().Vote(context.Background())
 	assert.Error(t, err)
 	assert.False(t, result)
 }
@@ -155,7 +156,7 @@ func TestVoteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Operations().Vote()
+	result, err := client.Operations().Vote(context.Background())
 	assert.Error(t, err)
 	assert.False(t, result)
 }

--- a/typesense/override.go
+++ b/typesense/override.go
@@ -8,8 +8,8 @@ import (
 
 // OverrideInterface is a type for Search Override API operations
 type OverrideInterface interface {
-	Retrieve() (*api.SearchOverride, error)
-	Delete() (*api.SearchOverride, error)
+	Retrieve(ctx context.Context) (*api.SearchOverride, error)
+	Delete(ctx context.Context) (*api.SearchOverride, error)
 }
 
 // override is internal implementation of OverrideInterface
@@ -19,8 +19,8 @@ type override struct {
 	overrideID     string
 }
 
-func (o *override) Retrieve() (*api.SearchOverride, error) {
-	response, err := o.apiClient.GetSearchOverrideWithResponse(context.Background(),
+func (o *override) Retrieve(ctx context.Context) (*api.SearchOverride, error) {
+	response, err := o.apiClient.GetSearchOverrideWithResponse(ctx,
 		o.collectionName, o.overrideID)
 	if err != nil {
 		return nil, err
@@ -31,8 +31,8 @@ func (o *override) Retrieve() (*api.SearchOverride, error) {
 	return response.JSON200, nil
 }
 
-func (o *override) Delete() (*api.SearchOverride, error) {
-	response, err := o.apiClient.DeleteSearchOverrideWithResponse(context.Background(),
+func (o *override) Delete(ctx context.Context) (*api.SearchOverride, error) {
+	response, err := o.apiClient.DeleteSearchOverrideWithResponse(ctx,
 		o.collectionName, o.overrideID)
 	if err != nil {
 		return nil, err

--- a/typesense/override_test.go
+++ b/typesense/override_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +30,7 @@ func TestSearchOverrideRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Override("customize-apple").Retrieve()
+	result, err := client.Collection("companies").Override("customize-apple").Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -46,7 +48,7 @@ func TestSearchOverrideRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Override("customize-apple").Retrieve()
+	_, err := client.Collection("companies").Override("customize-apple").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -67,7 +69,7 @@ func TestSearchOverrideRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Override("customize-apple").Retrieve()
+	_, err := client.Collection("companies").Override("customize-apple").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +89,7 @@ func TestSearchOverrideDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Override("customize-apple").Delete()
+	result, err := client.Collection("companies").Override("customize-apple").Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -105,7 +107,7 @@ func TestSearchOverrideDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Override("customize-apple").Delete()
+	_, err := client.Collection("companies").Override("customize-apple").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -126,6 +128,6 @@ func TestSearchOverrideDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Override("customize-apple").Delete()
+	_, err := client.Collection("companies").Override("customize-apple").Delete(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/overrides.go
+++ b/typesense/overrides.go
@@ -8,8 +8,8 @@ import (
 
 // OverridesInterface is a type for Search Overrides API operations
 type OverridesInterface interface {
-	Upsert(overrideID string, overrideSchema *api.SearchOverrideSchema) (*api.SearchOverride, error)
-	Retrieve() ([]*api.SearchOverride, error)
+	Upsert(ctx context.Context, overrideID string, overrideSchema *api.SearchOverrideSchema) (*api.SearchOverride, error)
+	Retrieve(ctx context.Context) ([]*api.SearchOverride, error)
 }
 
 // overrides is internal implementation of OverridesInterface
@@ -18,8 +18,8 @@ type overrides struct {
 	collectionName string
 }
 
-func (o *overrides) Upsert(overrideID string, overrideSchema *api.SearchOverrideSchema) (*api.SearchOverride, error) {
-	response, err := o.apiClient.UpsertSearchOverrideWithResponse(context.Background(),
+func (o *overrides) Upsert(ctx context.Context, overrideID string, overrideSchema *api.SearchOverrideSchema) (*api.SearchOverride, error) {
+	response, err := o.apiClient.UpsertSearchOverrideWithResponse(ctx,
 		o.collectionName, overrideID, api.UpsertSearchOverrideJSONRequestBody(*overrideSchema))
 	if err != nil {
 		return nil, err
@@ -30,8 +30,8 @@ func (o *overrides) Upsert(overrideID string, overrideSchema *api.SearchOverride
 	return response.JSON200, nil
 }
 
-func (o *overrides) Retrieve() ([]*api.SearchOverride, error) {
-	response, err := o.apiClient.GetSearchOverridesWithResponse(context.Background(), o.collectionName)
+func (o *overrides) Retrieve(ctx context.Context) ([]*api.SearchOverride, error) {
+	response, err := o.apiClient.GetSearchOverridesWithResponse(ctx, o.collectionName)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/overrides_test.go
+++ b/typesense/overrides_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jinzhu/copier"
@@ -63,7 +65,7 @@ func TestSearchOverrideUpsert(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchOverrideSchema()
-	result, err := client.Collection("companies").Overrides().Upsert("customize-apple", body)
+	result, err := client.Collection("companies").Overrides().Upsert(context.Background(), "customize-apple", body)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -85,7 +87,7 @@ func TestSearchOverrideUpsertOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchOverrideSchema()
-	_, err := client.Collection("companies").Overrides().Upsert("customize-apple", body)
+	_, err := client.Collection("companies").Overrides().Upsert(context.Background(), "customize-apple", body)
 	assert.NotNil(t, err)
 }
 
@@ -110,7 +112,7 @@ func TestSearchOverrideUpsertOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchOverrideSchema()
-	_, err := client.Collection("companies").Overrides().Upsert("customize-apple", body)
+	_, err := client.Collection("companies").Overrides().Upsert(context.Background(), "customize-apple", body)
 	assert.NotNil(t, err)
 }
 
@@ -137,7 +139,7 @@ func TestSearchOverridesRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("companies").Overrides().Retrieve()
+	result, err := client.Collection("companies").Overrides().Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -154,7 +156,7 @@ func TestSearchOverridesRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Overrides().Retrieve()
+	_, err := client.Collection("companies").Overrides().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -174,6 +176,6 @@ func TestSearchOverridesRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) 
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("companies").Overrides().Retrieve()
+	_, err := client.Collection("companies").Overrides().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/search_test.go
+++ b/typesense/search_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -127,7 +128,7 @@ func TestCollectionSearch(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	params := newSearchParams()
-	result, err := client.Collection("companies").Documents().Search(params)
+	result, err := client.Collection("companies").Documents().Search(context.Background(), params)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -147,7 +148,7 @@ func TestCollectionSearchOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	params := newSearchParams()
-	_, err := client.Collection("companies").Documents().Search(params)
+	_, err := client.Collection("companies").Documents().Search(context.Background(), params)
 	assert.NotNil(t, err)
 }
 
@@ -170,6 +171,6 @@ func TestCollectionSearchOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	params := newSearchParams()
-	_, err := client.Collection("companies").Documents().Search(params)
+	_, err := client.Collection("companies").Documents().Search(context.Background(), params)
 	assert.NotNil(t, err)
 }

--- a/typesense/synonym.go
+++ b/typesense/synonym.go
@@ -9,9 +9,9 @@ import (
 // SynonymInterface is a type for Search Synonym API operations
 type SynonymInterface interface {
 	// Retrieve a single search synonym
-	Retrieve() (*api.SearchSynonym, error)
+	Retrieve(ctx context.Context) (*api.SearchSynonym, error)
 	// Delete a synonym associated with a collection
-	Delete() (*api.SearchSynonym, error)
+	Delete(ctx context.Context) (*api.SearchSynonym, error)
 }
 
 // synonym is internal implementation of SynonymInterface
@@ -21,8 +21,8 @@ type synonym struct {
 	synonymID      string
 }
 
-func (s *synonym) Retrieve() (*api.SearchSynonym, error) {
-	response, err := s.apiClient.GetSearchSynonymWithResponse(context.Background(),
+func (s *synonym) Retrieve(ctx context.Context) (*api.SearchSynonym, error) {
+	response, err := s.apiClient.GetSearchSynonymWithResponse(ctx,
 		s.collectionName, s.synonymID)
 	if err != nil {
 		return nil, err
@@ -33,8 +33,8 @@ func (s *synonym) Retrieve() (*api.SearchSynonym, error) {
 	return response.JSON200, nil
 }
 
-func (s *synonym) Delete() (*api.SearchSynonym, error) {
-	response, err := s.apiClient.DeleteSearchSynonymWithResponse(context.Background(),
+func (s *synonym) Delete(ctx context.Context) (*api.SearchSynonym, error) {
+	response, err := s.apiClient.DeleteSearchSynonymWithResponse(ctx,
 		s.collectionName, s.synonymID)
 	if err != nil {
 		return nil, err

--- a/typesense/synonym_test.go
+++ b/typesense/synonym_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +30,7 @@ func TestSearchSynonymRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("products").Synonym("customize-apple").Retrieve()
+	result, err := client.Collection("products").Synonym("customize-apple").Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -46,7 +48,7 @@ func TestSearchSynonymRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonym("customize-apple").Retrieve()
+	_, err := client.Collection("products").Synonym("customize-apple").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -67,7 +69,7 @@ func TestSearchSynonymRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonym("customize-apple").Retrieve()
+	_, err := client.Collection("products").Synonym("customize-apple").Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -87,7 +89,7 @@ func TestSearchSynonymDelete(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("products").Synonym("customize-apple").Delete()
+	result, err := client.Collection("products").Synonym("customize-apple").Delete(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -105,7 +107,7 @@ func TestSearchSynonymDeleteOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonym("customize-apple").Delete()
+	_, err := client.Collection("products").Synonym("customize-apple").Delete(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -126,6 +128,6 @@ func TestSearchSynonymDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonym("customize-apple").Delete()
+	_, err := client.Collection("products").Synonym("customize-apple").Delete(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/synonyms.go
+++ b/typesense/synonyms.go
@@ -9,9 +9,9 @@ import (
 // SynonymsInterface is a type for Search Synonyms API operations
 type SynonymsInterface interface {
 	// Create or update a synonym
-	Upsert(synonymID string, synonymSchema *api.SearchSynonymSchema) (*api.SearchSynonym, error)
+	Upsert(ctx context.Context, synonymID string, synonymSchema *api.SearchSynonymSchema) (*api.SearchSynonym, error)
 	// List all collection synonyms
-	Retrieve() ([]*api.SearchSynonym, error)
+	Retrieve(ctx context.Context) ([]*api.SearchSynonym, error)
 }
 
 // synonyms is internal implementation of SynonymsInterface
@@ -20,8 +20,8 @@ type synonyms struct {
 	collectionName string
 }
 
-func (s *synonyms) Upsert(synonymID string, synonymSchema *api.SearchSynonymSchema) (*api.SearchSynonym, error) {
-	response, err := s.apiClient.UpsertSearchSynonymWithResponse(context.Background(),
+func (s *synonyms) Upsert(ctx context.Context, synonymID string, synonymSchema *api.SearchSynonymSchema) (*api.SearchSynonym, error) {
+	response, err := s.apiClient.UpsertSearchSynonymWithResponse(ctx,
 		s.collectionName, synonymID, api.UpsertSearchSynonymJSONRequestBody(*synonymSchema))
 	if err != nil {
 		return nil, err
@@ -32,8 +32,8 @@ func (s *synonyms) Upsert(synonymID string, synonymSchema *api.SearchSynonymSche
 	return response.JSON200, nil
 }
 
-func (s *synonyms) Retrieve() ([]*api.SearchSynonym, error) {
-	response, err := s.apiClient.GetSearchSynonymsWithResponse(context.Background(), s.collectionName)
+func (s *synonyms) Retrieve(ctx context.Context) ([]*api.SearchSynonym, error) {
+	response, err := s.apiClient.GetSearchSynonymsWithResponse(ctx, s.collectionName)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/synonyms_test.go
+++ b/typesense/synonyms_test.go
@@ -1,10 +1,12 @@
 package typesense
 
 import (
+	"context"
 	"errors"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
 	"net/http"
 	"testing"
+
+	"github.com/typesense/typesense-go/typesense/api/pointer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/jinzhu/copier"
@@ -45,7 +47,7 @@ func TestSearchSynonymUpsert(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchSynonymSchema()
-	result, err := client.Collection("products").Synonyms().Upsert("coat-synonyms", body)
+	result, err := client.Collection("products").Synonyms().Upsert(context.Background(), "coat-synonyms", body)
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -67,7 +69,7 @@ func TestSearchSynonymUpsertOnApiClientErrorReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchSynonymSchema()
-	_, err := client.Collection("products").Synonyms().Upsert("coat-synonyms", body)
+	_, err := client.Collection("products").Synonyms().Upsert(context.Background(), "coat-synonyms", body)
 	assert.NotNil(t, err)
 }
 
@@ -92,7 +94,7 @@ func TestSearchSynonymUpsertOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 
 	client := NewClient(WithAPIClient(mockAPIClient))
 	body := createNewSearchSynonymSchema()
-	_, err := client.Collection("products").Synonyms().Upsert("coat-synonyms", body)
+	_, err := client.Collection("products").Synonyms().Upsert(context.Background(), "coat-synonyms", body)
 	assert.NotNil(t, err)
 }
 
@@ -119,7 +121,7 @@ func TestSearchSynonymsRetrieve(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	result, err := client.Collection("products").Synonyms().Retrieve()
+	result, err := client.Collection("products").Synonyms().Retrieve(context.Background())
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedResult, result)
@@ -137,7 +139,7 @@ func TestSearchSynonymsRetrieveOnApiClientErrorReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonyms().Retrieve()
+	_, err := client.Collection("products").Synonyms().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }
 
@@ -158,6 +160,6 @@ func TestSearchSynonymsRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
 		Times(1)
 
 	client := NewClient(WithAPIClient(mockAPIClient))
-	_, err := client.Collection("products").Synonyms().Retrieve()
+	_, err := client.Collection("products").Synonyms().Retrieve(context.Background())
 	assert.NotNil(t, err)
 }

--- a/typesense/test/alias_test.go
+++ b/typesense/test/alias_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,10 +17,10 @@ func TestCollectionAliasRetrieve(t *testing.T) {
 	expectedResult := newCollectionAlias(collectionName, aliasName)
 
 	body := &api.CollectionAliasSchema{CollectionName: collectionName}
-	_, err := typesenseClient.Aliases().Upsert(aliasName, body)
+	_, err := typesenseClient.Aliases().Upsert(context.Background(), aliasName, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Alias(aliasName).Retrieve()
+	result, err := typesenseClient.Alias(aliasName).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -30,14 +32,14 @@ func TestCollectionAliasDelete(t *testing.T) {
 	expectedResult := newCollectionAlias(collectionName, aliasName)
 
 	body := &api.CollectionAliasSchema{CollectionName: collectionName}
-	_, err := typesenseClient.Aliases().Upsert(aliasName, body)
+	_, err := typesenseClient.Aliases().Upsert(context.Background(), aliasName, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Alias(aliasName).Delete()
+	result, err := typesenseClient.Alias(aliasName).Delete(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	_, err = typesenseClient.Alias(aliasName).Retrieve()
+	_, err = typesenseClient.Alias(aliasName).Retrieve(context.Background())
 	require.Error(t, err)
 }

--- a/typesense/test/aliases_test.go
+++ b/typesense/test/aliases_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,12 +18,12 @@ func TestCollectionAliasUpsertNewAlias(t *testing.T) {
 	expectedResult := newCollectionAlias(collectionName, aliasName)
 
 	body := &api.CollectionAliasSchema{CollectionName: collectionName}
-	result, err := typesenseClient.Aliases().Upsert(aliasName, body)
+	result, err := typesenseClient.Aliases().Upsert(context.Background(), aliasName, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Alias(aliasName).Retrieve()
+	result, err = typesenseClient.Alias(aliasName).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -35,16 +36,16 @@ func TestCollectionAliasUpsertExistingAlias(t *testing.T) {
 	expectedResult := newCollectionAlias(collectionName2, aliasName)
 
 	body := &api.CollectionAliasSchema{CollectionName: collectionName1}
-	_, err := typesenseClient.Aliases().Upsert(aliasName, body)
+	_, err := typesenseClient.Aliases().Upsert(context.Background(), aliasName, body)
 	require.NoError(t, err)
 
 	body = &api.CollectionAliasSchema{CollectionName: collectionName2}
-	result, err := typesenseClient.Aliases().Upsert(aliasName, body)
+	result, err := typesenseClient.Aliases().Upsert(context.Background(), aliasName, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Alias(aliasName).Retrieve()
+	result, err = typesenseClient.Alias(aliasName).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -64,11 +65,11 @@ func TestCollectionAliasesRetrieve(t *testing.T) {
 	}
 
 	for i := 0; i < total; i++ {
-		_, err := typesenseClient.Aliases().Upsert(aliasNames[i], body)
+		_, err := typesenseClient.Aliases().Upsert(context.Background(), aliasNames[i], body)
 		require.NoError(t, err)
 	}
 
-	result, err := typesenseClient.Aliases().Retrieve()
+	result, err := typesenseClient.Aliases().Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.True(t, len(result) >= total, "number of aliases is invalid")

--- a/typesense/test/collection_test.go
+++ b/typesense/test/collection_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ func TestCollectionRetrieve(t *testing.T) {
 	collectionName := createNewCollection(t, "companies")
 	expectedResult := expectedNewCollection(collectionName)
 
-	result, err := typesenseClient.Collection(collectionName).Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Retrieve(context.Background())
 	result.CreatedAt = pointer.Int64(0)
 
 	require.NoError(t, err)
@@ -26,12 +27,12 @@ func TestCollectionDelete(t *testing.T) {
 	collectionName := createNewCollection(t, "companies")
 	expectedResult := expectedNewCollection(collectionName)
 
-	result, err := typesenseClient.Collection(collectionName).Delete()
+	result, err := typesenseClient.Collection(collectionName).Delete(context.Background())
 	result.CreatedAt = pointer.Int64(0)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	_, err = typesenseClient.Collection(collectionName).Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Retrieve(context.Background())
 	require.Error(t, err)
 }
 
@@ -47,7 +48,7 @@ func TestCollectionUpdate(t *testing.T) {
 		},
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Update(updateSchema)
+	result, err := typesenseClient.Collection(collectionName).Update(context.Background(), updateSchema)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(result.Fields))
 	require.Equal(t, "country", result.Fields[0].Name)

--- a/typesense/test/collections_test.go
+++ b/typesense/test/collections_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestCollectionCreate(t *testing.T) {
 	schema := newSchema(collectionName)
 	expectedResult := expectedNewCollection(collectionName)
 
-	result, err := typesenseClient.Collections().Create(schema)
+	result, err := typesenseClient.Collections().Create(context.Background(), schema)
 	result.CreatedAt = pointer.Int64(0)
 
 	require.NoError(t, err)
@@ -40,11 +41,11 @@ func TestCollectionsRetrieve(t *testing.T) {
 	}
 
 	for _, schema := range schemas {
-		_, err := typesenseClient.Collections().Create(schema)
+		_, err := typesenseClient.Collections().Create(context.Background(), schema)
 		require.NoError(t, err)
 	}
 
-	result, err := typesenseClient.Collections().Retrieve()
+	result, err := typesenseClient.Collections().Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.True(t, len(result) >= total, "number of collections is invalid")

--- a/typesense/test/dbhelpers_test.go
+++ b/typesense/test/dbhelpers_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -270,14 +271,14 @@ func createNewCollection(t *testing.T, namePrefix string) string {
 	collectionName := newUUIDName(namePrefix)
 	schema := newSchema(collectionName)
 
-	_, err := typesenseClient.Collections().Create(schema)
+	_, err := typesenseClient.Collections().Create(context.Background(), schema)
 	require.NoError(t, err)
 	return collectionName
 }
 
 func createDocument(t *testing.T, collectionName string, document *testDocument) {
 	t.Helper()
-	_, err := typesenseClient.Collection(collectionName).Documents().Create(document)
+	_, err := typesenseClient.Collection(collectionName).Documents().Create(context.Background(), document)
 	require.NoError(t, err)
 }
 
@@ -285,7 +286,7 @@ func createNewKey(t *testing.T) *api.ApiKey {
 	t.Helper()
 	keySchema := newKeySchema()
 
-	result, err := typesenseClient.Keys().Create(keySchema)
+	result, err := typesenseClient.Keys().Create(context.Background(), keySchema)
 
 	require.NoError(t, err)
 	return result
@@ -294,7 +295,7 @@ func createNewKey(t *testing.T) *api.ApiKey {
 func retrieveDocuments(t *testing.T, collectionName string, docIDs ...string) []map[string]interface{} {
 	results := make([]map[string]interface{}, len(docIDs))
 	for i, docID := range docIDs {
-		doc, err := typesenseClient.Collection(collectionName).Document(docID).Retrieve()
+		doc, err := typesenseClient.Collection(collectionName).Document(docID).Retrieve(context.Background())
 		require.NoError(t, err)
 		results[i] = doc
 	}

--- a/typesense/test/document_test.go
+++ b/typesense/test/document_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +15,7 @@ func TestDocumentRetrieve(t *testing.T) {
 	expectedResult := newDocumentResponse("123")
 	createDocument(t, collectionName, newDocument("123"))
 
-	result, err := typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -28,9 +30,9 @@ func TestDocumentUpdate(t *testing.T) {
 	createDocument(t, collectionName, document)
 
 	document.CompanyName = newCompanyName
-	typesenseClient.Collection(collectionName).Document("123").Update(document)
+	typesenseClient.Collection(collectionName).Document("123").Update(context.Background(), document)
 
-	result, err := typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -41,11 +43,11 @@ func TestDocumentDelete(t *testing.T) {
 	expectedResult := newDocumentResponse("123")
 	createDocument(t, collectionName, newDocument("123"))
 
-	result, err := typesenseClient.Collection(collectionName).Document("123").Delete()
+	result, err := typesenseClient.Collection(collectionName).Document("123").Delete(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	_, err = typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 	require.Error(t, err)
 }

--- a/typesense/test/documents_test.go
+++ b/typesense/test/documents_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -17,12 +19,12 @@ func TestDocumentCreate(t *testing.T) {
 	expectedResult := newDocumentResponse("123")
 
 	document := newDocument("123")
-	result, err := typesenseClient.Collection(collectionName).Documents().Create(document)
+	result, err := typesenseClient.Collection(collectionName).Documents().Create(context.Background(), document)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -33,12 +35,12 @@ func TestDocumentUpsertNewDocument(t *testing.T) {
 	expectedResult := newDocumentResponse("123")
 
 	document := newDocument("123")
-	result, err := typesenseClient.Collection(collectionName).Documents().Upsert(document)
+	result, err := typesenseClient.Collection(collectionName).Documents().Upsert(context.Background(), document)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -50,17 +52,17 @@ func TestDocumentUpsertExistingDocument(t *testing.T) {
 	expectedResult := newDocumentResponse("123", withResponseCompanyName(newCompanyName))
 
 	document := newDocument("123")
-	_, err := typesenseClient.Collection(collectionName).Documents().Create(document)
+	_, err := typesenseClient.Collection(collectionName).Documents().Create(context.Background(), document)
 	require.NoError(t, err)
 
 	document.CompanyName = newCompanyName
 
-	result, err := typesenseClient.Collection(collectionName).Documents().Upsert(document)
+	result, err := typesenseClient.Collection(collectionName).Documents().Upsert(context.Background(), document)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -71,23 +73,23 @@ func TestDocumentsDelete(t *testing.T) {
 
 	document := newDocument("123")
 	document.NumEmployees = 5000
-	_, err := typesenseClient.Collection(collectionName).Documents().Create(document)
+	_, err := typesenseClient.Collection(collectionName).Documents().Create(context.Background(), document)
 	require.NoError(t, err)
 
 	document = newDocument("124")
 	document.NumEmployees = 7000
-	_, err = typesenseClient.Collection(collectionName).Documents().Create(document)
+	_, err = typesenseClient.Collection(collectionName).Documents().Create(context.Background(), document)
 	require.NoError(t, err)
 
 	filter := &api.DeleteDocumentsParams{FilterBy: pointer.String("num_employees:>6500"), BatchSize: pointer.Int(100)}
-	result, err := typesenseClient.Collection(collectionName).Documents().Delete(filter)
+	result, err := typesenseClient.Collection(collectionName).Documents().Delete(context.Background(), filter)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, result)
 
-	_, err = typesenseClient.Collection(collectionName).Document("123").Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Document("123").Retrieve(context.Background())
 	require.NoError(t, err)
-	_, err = typesenseClient.Collection(collectionName).Document("124").Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Document("124").Retrieve(context.Background())
 	require.Error(t, err)
 }
 
@@ -104,7 +106,7 @@ func TestDocumentsExport(t *testing.T) {
 	createDocument(t, collectionName, newDocument("125", withCompanyName("Company2")))
 	createDocument(t, collectionName, newDocument("127", withCompanyName("Company3")))
 
-	body, err := typesenseClient.Collection(collectionName).Documents().Export()
+	body, err := typesenseClient.Collection(collectionName).Documents().Export(context.Background())
 	require.NoError(t, err)
 	defer body.Close()
 

--- a/typesense/test/health_test.go
+++ b/typesense/test/health_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,7 +13,7 @@ import (
 
 func TestHealthStatus(t *testing.T) {
 	t.Parallel()
-	healthy, err := typesenseClient.Health(2 * time.Second)
+	healthy, err := typesenseClient.Health(context.Background(), 2*time.Second)
 	assert.NoError(t, err)
 	assert.True(t, healthy)
 }

--- a/typesense/test/import_test.go
+++ b/typesense/test/import_test.go
@@ -1,9 +1,11 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -28,7 +30,7 @@ func TestDocumentsImport(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	responses, err := typesenseClient.Collection(collectionName).Documents().Import(documents, params)
+	responses, err := typesenseClient.Collection(collectionName).Documents().Import(context.Background(), documents, params)
 
 	require.NoError(t, err)
 	for _, response := range responses {
@@ -57,7 +59,7 @@ func TestDocumentsImportJsonl(t *testing.T) {
 	require.NoError(t, je.Encode(newDocument("127", withCompanyName("Company3"))))
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	responses, err := typesenseClient.Collection(collectionName).Documents().ImportJsonl(&buffer, params)
+	responses, err := typesenseClient.Collection(collectionName).Documents().ImportJsonl(context.Background(), &buffer, params)
 
 	require.NoError(t, err)
 	defer responses.Close()

--- a/typesense/test/key_test.go
+++ b/typesense/test/key_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 func TestKeyRetrieve(t *testing.T) {
 	expectedKey := createNewKey(t)
 
-	result, err := typesenseClient.Key(*expectedKey.Id).Retrieve()
+	result, err := typesenseClient.Key(*expectedKey.Id).Retrieve(context.Background())
 
 	require.NoError(t, err)
 
@@ -27,11 +28,11 @@ func TestKeyRetrieve(t *testing.T) {
 func TestKeyDelete(t *testing.T) {
 	expectedKey := createNewKey(t)
 
-	result, err := typesenseClient.Key(*expectedKey.Id).Delete()
+	result, err := typesenseClient.Key(*expectedKey.Id).Delete(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedKey.Id, result.Id)
 
-	_, err = typesenseClient.Key(*expectedKey.Id).Retrieve()
+	_, err = typesenseClient.Key(*expectedKey.Id).Retrieve(context.Background())
 	require.Error(t, err)
 }

--- a/typesense/test/keys_test.go
+++ b/typesense/test/keys_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestKeyCreate(t *testing.T) {
 	keySchema := newKeySchema()
 	expectedResult := newKey()
 
-	result, err := typesenseClient.Keys().Create(keySchema)
+	result, err := typesenseClient.Keys().Create(context.Background(), keySchema)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult.Description, result.Description)
@@ -27,7 +28,7 @@ func TestKeyCreate(t *testing.T) {
 func TestKeysRetrieve(t *testing.T) {
 	expectedKey := createNewKey(t)
 
-	results, err := typesenseClient.Keys().Retrieve()
+	results, err := typesenseClient.Keys().Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.True(t, len(results) >= 1, "number of keys is invalid")

--- a/typesense/test/multi_search_test.go
+++ b/typesense/test/multi_search_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,10 +24,10 @@ func TestMultiSearch(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	_, err := typesenseClient.Collection(collectionName1).Documents().Import(documents, params)
+	_, err := typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
-	_, err = typesenseClient.Collection(collectionName1).Documents().Import(documents, params)
+	_, err = typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.MultiSearchParams{
@@ -63,7 +64,7 @@ func TestMultiSearch(t *testing.T) {
 		newDocumentResponse("131", withResponseCompanyName("Stark Industries 5"), withResponseNumEmployees(1000)),
 	}
 
-	result, err := typesenseClient.MultiSearch.Perform(searchParams, searches)
+	result, err := typesenseClient.MultiSearch.Perform(context.Background(), searchParams, searches)
 	require.NoError(t, err)
 
 	require.Equal(t, 3, len(result.Results))
@@ -92,7 +93,7 @@ func TestMultiSearchGroupBy(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	_, err := typesenseClient.Collection(collectionName1).Documents().Import(documents, params)
+	_, err := typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.MultiSearchParams{
@@ -117,7 +118,7 @@ func TestMultiSearchGroupBy(t *testing.T) {
 		}
 	*/
 
-	result, err := typesenseClient.MultiSearch.Perform(searchParams, searches)
+	result, err := typesenseClient.MultiSearch.Perform(context.Background(), searchParams, searches)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(result.Results))
 	require.NotNil(t, result.Results[0].GroupedHits)
@@ -138,7 +139,7 @@ func TestMultiSearchGroupBy(t *testing.T) {
 }
 
 func TestMultiSearchVectorQuery(t *testing.T) {
-	_, err := typesenseClient.Collection("embeddings").Delete()
+	_, err := typesenseClient.Collection("embeddings").Delete(context.Background())
 
 	collSchema := api.CollectionSchema{
 		Name: "embeddings",
@@ -155,7 +156,7 @@ func TestMultiSearchVectorQuery(t *testing.T) {
 		},
 	}
 
-	_, err = typesenseClient.Collections().Create(&collSchema)
+	_, err = typesenseClient.Collections().Create(context.Background(), &collSchema)
 	require.NoError(t, err)
 
 	type vecDocument struct {
@@ -170,7 +171,7 @@ func TestMultiSearchVectorQuery(t *testing.T) {
 		Vec:   []float32{0.45, 0.222, 0.021, 0.1323},
 	}
 
-	_, err = typesenseClient.Collection("embeddings").Documents().Create(vecDoc)
+	_, err = typesenseClient.Collection("embeddings").Documents().Create(context.Background(), vecDoc)
 	require.NoError(t, err)
 
 	searchParams := &api.MultiSearchParams{}
@@ -184,7 +185,7 @@ func TestMultiSearchVectorQuery(t *testing.T) {
 		},
 	}
 
-	searchResp, err := typesenseClient.MultiSearch.Perform(searchParams, searches)
+	searchResp, err := typesenseClient.MultiSearch.Perform(context.Background(), searchParams, searches)
 	require.NoError(t, err)
 
 	require.NotNil(t, searchResp.Results[0].Hits)

--- a/typesense/test/override_test.go
+++ b/typesense/test/override_test.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,10 +16,10 @@ func TestSearchOverrideRetrieve(t *testing.T) {
 	expectedResult := newSearchOverride(overrideID)
 
 	body := newSearchOverrideSchema()
-	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideID, body)
+	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideID, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Collection(collectionName).Override(overrideID).Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Override(overrideID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -29,14 +31,14 @@ func TestSearchOverrideDelete(t *testing.T) {
 	expectedResult := newSearchOverride(overrideID)
 
 	body := newSearchOverrideSchema()
-	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideID, body)
+	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideID, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Collection(collectionName).Override(overrideID).Delete()
+	result, err := typesenseClient.Collection(collectionName).Override(overrideID).Delete(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult.Id, result.Id)
 
-	_, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve(context.Background())
 	require.Error(t, err)
 }

--- a/typesense/test/overrides_test.go
+++ b/typesense/test/overrides_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,12 +18,12 @@ func TestSearchOverrideUpsertNewOverride(t *testing.T) {
 	expectedResult := newSearchOverride(overrideID)
 
 	body := newSearchOverrideSchema()
-	result, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideID, body)
+	result, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideID, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -36,17 +37,17 @@ func TestSearchOverrideUpsertExistingOverride(t *testing.T) {
 
 	body := newSearchOverrideSchema()
 	body.Rule.Match = "exact"
-	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideID, body)
+	_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideID, body)
 	require.NoError(t, err)
 
 	body.Rule.Match = "contains"
 
-	result, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideID, body)
+	result, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideID, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Override(overrideID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
@@ -66,11 +67,11 @@ func TestSearchOverridesRetrieve(t *testing.T) {
 	}
 
 	for i := 0; i < total; i++ {
-		_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(overrideIDs[i], schema)
+		_, err := typesenseClient.Collection(collectionName).Overrides().Upsert(context.Background(), overrideIDs[i], schema)
 		require.NoError(t, err)
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Overrides().Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Overrides().Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.True(t, len(result) >= total, "number of overrides is invalid")

--- a/typesense/test/search_test.go
+++ b/typesense/test/search_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,7 @@ func TestCollectionSearch(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	_, err := typesenseClient.Collection(collectionName).Documents().Import(documents, params)
+	_, err := typesenseClient.Collection(collectionName).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.SearchCollectionParams{
@@ -43,7 +44,7 @@ func TestCollectionSearch(t *testing.T) {
 			withResponseNumEmployees(150)),
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Documents().Search(searchParams)
+	result, err := typesenseClient.Collection(collectionName).Documents().Search(context.Background(), searchParams)
 
 	require.NoError(t, err)
 	require.Equal(t, 2, *result.Found, "found documents number is invalid")
@@ -67,7 +68,7 @@ func TestCollectionSearchRange(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	_, err := typesenseClient.Collection(collectionName).Documents().Import(documents, params)
+	_, err := typesenseClient.Collection(collectionName).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.SearchCollectionParams{
@@ -86,7 +87,7 @@ func TestCollectionSearchRange(t *testing.T) {
 			withResponseNumEmployees(250)),
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Documents().Search(searchParams)
+	result, err := typesenseClient.Collection(collectionName).Documents().Search(context.Background(), searchParams)
 
 	require.NoError(t, err)
 	require.Equal(t, 2, *result.Found, "found documents number is invalid")
@@ -102,7 +103,7 @@ func TestCollectionSearchRange(t *testing.T) {
 
 func TestCollectionGroupByStringArray(t *testing.T) {
 	collectionName := "tags"
-	_, err := typesenseClient.Collection(collectionName).Delete()
+	_, err := typesenseClient.Collection(collectionName).Delete(context.Background())
 
 	schema := &api.CollectionSchema{
 		Name: collectionName,
@@ -115,7 +116,7 @@ func TestCollectionGroupByStringArray(t *testing.T) {
 		},
 	}
 
-	_, err = typesenseClient.Collections().Create(schema)
+	_, err = typesenseClient.Collections().Create(context.Background(), schema)
 	require.NoError(t, err)
 
 	type docWithArray struct {
@@ -131,7 +132,7 @@ func TestCollectionGroupByStringArray(t *testing.T) {
 	}
 
 	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
-	_, err = typesenseClient.Collection(collectionName).Documents().Import(documents, params)
+	_, err = typesenseClient.Collection(collectionName).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.SearchCollectionParams{
@@ -139,7 +140,7 @@ func TestCollectionGroupByStringArray(t *testing.T) {
 		GroupBy: pointer.String("tags"),
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Documents().Search(searchParams)
+	result, err := typesenseClient.Collection(collectionName).Documents().Search(context.Background(), searchParams)
 	require.NoError(t, err)
 
 	require.NoError(t, err)

--- a/typesense/test/setupdb_test.go
+++ b/typesense/test/setupdb_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !docker
 // +build integration,!docker
 
 package test
@@ -19,7 +20,7 @@ func waitHealthyStatus(client *typesense.Client, timeout time.Duration) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-time.After(1 * time.Second):
-			if healthy, _ := client.Health(2 * time.Second); !healthy {
+			if healthy, _ := client.Health(context.Background(), 2*time.Second); !healthy {
 				continue
 			}
 			return nil

--- a/typesense/test/synonym_test.go
+++ b/typesense/test/synonym_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,10 +17,10 @@ func TestSearchSynonymRetrieve(t *testing.T) {
 	expectedResult := newSearchSynonym(synonymID)
 
 	body := newSearchSynonymSchema()
-	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymID, body)
+	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymID, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	expectedResult.Root = pointer.String("")
@@ -32,14 +33,14 @@ func TestSearchSynonymDelete(t *testing.T) {
 	expectedResult := newSearchSynonym(synonymID)
 
 	body := newSearchSynonymSchema()
-	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymID, body)
+	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymID, body)
 	require.NoError(t, err)
 
-	result, err := typesenseClient.Collection(collectionName).Synonym(synonymID).Delete()
+	result, err := typesenseClient.Collection(collectionName).Synonym(synonymID).Delete(context.Background())
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult.Id, result.Id)
 
-	_, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve()
+	_, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve(context.Background())
 	require.Error(t, err)
 }

--- a/typesense/test/synonyms_test.go
+++ b/typesense/test/synonyms_test.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,12 +19,12 @@ func TestSearchSynonymUpsertNewSynonym(t *testing.T) {
 	expectedResult := newSearchSynonym(synonymID)
 
 	body := newSearchSynonymSchema()
-	result, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymID, body)
+	result, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymID, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	expectedResult.Root = pointer.String("")
@@ -37,17 +38,17 @@ func TestSearchSynonymUpsertExistingSynonym(t *testing.T) {
 	expectedResult.Synonyms = []string{"blazer", "coat", "jacket"}
 
 	body := newSearchSynonymSchema(withSynonyms("blazer", "coat"))
-	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymID, body)
+	_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymID, body)
 	require.NoError(t, err)
 
 	body.Synonyms = []string{"blazer", "coat", "jacket"}
 
-	result, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymID, body)
+	result, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymID, body)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 
-	result, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve()
+	result, err = typesenseClient.Collection(collectionName).Synonym(synonymID).Retrieve(context.Background())
 
 	require.NoError(t, err)
 	expectedResult.Root = pointer.String("")
@@ -68,11 +69,11 @@ func TestSearchSynonymsRetrieve(t *testing.T) {
 	}
 
 	for i := 0; i < total; i++ {
-		_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(synonymIDs[i], schema)
+		_, err := typesenseClient.Collection(collectionName).Synonyms().Upsert(context.Background(), synonymIDs[i], schema)
 		require.NoError(t, err)
 	}
 
-	result, err := typesenseClient.Collection(collectionName).Synonyms().Retrieve()
+	result, err := typesenseClient.Collection(collectionName).Synonyms().Retrieve(context.Background())
 
 	require.NoError(t, err)
 	require.True(t, len(result) >= total, "number of overrides is invalid")


### PR DESCRIPTION
Thanks so much for creating Typesense and hosting the Go SDK! I would _really_ like to pass my application's context when doing my batch imports so that I can properly cancel it and propagate timeouts. I made all such changes that I could see. Let me know if there are any missing.

## Change Summary
All functions that were calling the OpenAPI generated code with a `context.Background()` have been changed to take a context argument.

This is obviously a breaking change in terms of function signatures, so let me know if you'd rather we do something else. We could e.g. add a `DeleteContext` function, a `RetrieveContext` function etc.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

Closes #143.