### PR TITLE
add support for nearest node & multiple nodes load balancing

### DIFF
--- a/typesense/api_call.go
+++ b/typesense/api_call.go
@@ -1,0 +1,139 @@
+package typesense
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/typesense/typesense-go/typesense/api/circuit"
+)
+
+type ApiCall struct {
+	client               circuit.HTTPRequestDoer
+	nearestNode          *Node
+	nodes                []Node
+	currentNodeIndex     int
+	healthcheckInterval  time.Duration
+	numRetriesPerRequest int
+	retryInterval        time.Duration
+}
+
+type Node struct {
+	isHealthy           bool
+	index               interface{}
+	url                 string
+	lastAccessTimestamp int64
+}
+
+var apiCallTimeNow = time.Now // for test stubbing
+
+const (
+	HEALTHY   = true
+	UNHEALTHY = false
+)
+
+type ApiCallOption func(*ApiCall)
+
+func NewApiCall(client circuit.HTTPRequestDoer, config *ClientConfig) *ApiCall {
+	apiCall := &ApiCall{
+		currentNodeIndex:     -1,
+		healthcheckInterval:  config.HealthcheckInterval,
+		client:               client,
+		numRetriesPerRequest: config.NumRetries,
+		retryInterval:        config.RetryInterval,
+	}
+
+	// default numRetries is the number of nodes (+1 if nearestNode is specified)
+	if config.NumRetries == 0 {
+		apiCall.numRetriesPerRequest = len(config.Nodes)
+		if config.NearestNode != "" {
+			apiCall.numRetriesPerRequest++
+		}
+	}
+
+	apiCall.initializeNodesMetadata(config)
+
+	return apiCall
+}
+
+func (a *ApiCall) Do(req *http.Request) (*http.Response, error) {
+	// Default is to not load balance for backward compatibility
+	if len(a.nodes) == 0 {
+		res, err := a.client.Do(req)
+		return res, err
+	}
+
+	var lastResponse *http.Response
+	var lastError error
+
+	for numTries := 0; numTries < a.numRetriesPerRequest; numTries++ {
+		node := a.getNextNode()
+
+		replaceRequestHostname(req, node.url)
+
+		response, err := a.client.Do(req)
+
+		// If conection timeouts or status 5xx, retry
+		if err != nil || response.StatusCode >= 500 {
+			lastResponse = response
+			lastError = err
+
+			setNodeHealthCheck(node, UNHEALTHY)
+			time.Sleep(a.retryInterval)
+			continue
+		} else if response.StatusCode >= 1 && response.StatusCode <= 499 {
+			// Treat any status code > 0 and < 500 to be an indication that node is healthy
+			// We exclude 0 since some clients return 0 when request fails
+			setNodeHealthCheck(node, HEALTHY)
+			return response, err
+		}
+	}
+
+	return lastResponse, lastError
+}
+
+func (a *ApiCall) getNextNode() *Node {
+	if a.nearestNode != nil && (a.nearestNode.isHealthy || a.nodeDueForHealthcheck(a.nearestNode)) {
+		return a.nearestNode
+	}
+
+	candidateNode := &a.nodes[0]
+	for i := 0; i <= len(a.nodes); i++ {
+		a.currentNodeIndex = (a.currentNodeIndex + 1) % len(a.nodes)
+		candidateNode = &a.nodes[a.currentNodeIndex]
+		if candidateNode.isHealthy || a.nodeDueForHealthcheck(candidateNode) {
+			return candidateNode
+		}
+	}
+	// None of the nodes are marked healthy, but some of them could have become healthy since last health check.
+	// So we will just return the next node.
+	return candidateNode
+}
+
+func (a *ApiCall) initializeNodesMetadata(config *ClientConfig) {
+	if config.NearestNode != "" {
+		a.nearestNode = &Node{index: "nearestNode", url: config.NearestNode}
+		setNodeHealthCheck(a.nearestNode, HEALTHY)
+	}
+	a.nodes = make([]Node, 0, len(config.Nodes))
+	for i, v := range config.Nodes {
+		a.nodes = append(a.nodes, Node{isHealthy: true, index: i, url: v, lastAccessTimestamp: apiCallTimeNow().UnixMilli()})
+	}
+}
+
+func replaceRequestHostname(req *http.Request, URL string) {
+	newURL, _ := url.Parse(URL)
+
+	req.URL.Scheme = newURL.Scheme
+	req.URL.Host = newURL.Host
+	req.Host = newURL.Host
+}
+
+func setNodeHealthCheck(node *Node, isHealthy bool) {
+	node.isHealthy = isHealthy
+	node.lastAccessTimestamp = apiCallTimeNow().UnixMilli()
+}
+
+func (a *ApiCall) nodeDueForHealthcheck(node *Node) bool {
+	return apiCallTimeNow().UnixMilli()-node.lastAccessTimestamp > a.healthcheckInterval.Milliseconds()
+}

--- a/typesense/api_call_test.go
+++ b/typesense/api_call_test.go
@@ -1,0 +1,351 @@
+package typesense
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type serverHandler func(http.ResponseWriter, *http.Request)
+
+func newHTTPRequest(t *testing.T, urls ...string) *http.Request {
+	t.Helper()
+	url := "http://example.com/collections/1?test=1"
+	if len(urls) != 0 {
+		url = urls[0]
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	assert.NoError(t, err)
+	return req
+}
+
+func newApiCall(apiConfig *ClientConfig) *ApiCall {
+	return NewApiCall(
+		&http.Client{
+			Timeout: apiConfig.ConnectionTimeout,
+		},
+		apiConfig,
+	)
+}
+
+func instantiateServers(handlers []serverHandler) ([]*httptest.Server, []string) {
+	servers := make([]*httptest.Server, 0, len(handlers))
+	serverURLs := make([]string, 0, len(handlers))
+	for _, handler := range handlers {
+		server := httptest.NewServer(http.HandlerFunc(handler))
+		servers = append(servers, server)
+		serverURLs = append(serverURLs, server.URL)
+	}
+	return servers, serverURLs
+}
+
+func freezeUnixMilli(msec int64) {
+	apiCallTimeNow = func() time.Time {
+		return time.UnixMilli(msec)
+	}
+}
+
+// * When NearestNode is not specified
+func TestApiCallDoesNotRetryWhenStatusCodeIs3xxOr4xx(t *testing.T) {
+
+	requestUrlHistory := make([]string, 0, 2)
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(301)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(409)
+		},
+	})
+	for _, server := range servers {
+		defer server.Close()
+	}
+
+	apiCall := newApiCall(
+		&ClientConfig{
+			Nodes:             serverURLs,
+			ConnectionTimeout: 5 * time.Second,
+		},
+	)
+	req := newHTTPRequest(t)
+
+	res, err := apiCall.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 301, res.StatusCode)
+
+	res2, err2 := apiCall.Do(req)
+	assert.NoError(t, err2)
+	assert.Equal(t, 409, res2.StatusCode)
+
+	assert.Equal(t, serverURLs, requestUrlHistory)
+}
+
+type timeoutError struct {
+	err     string
+	timeout bool
+}
+
+func (e *timeoutError) Error() string {
+	return e.err
+}
+
+func (e *timeoutError) Timeout() bool {
+	return e.timeout
+}
+
+type mockClient struct{}
+
+func (m *mockClient) Do(req *http.Request) (*http.Response, error) {
+	(&http.Client{}).Do(req)
+	return nil, &timeoutError{
+		err:     "context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+		timeout: true,
+	}
+}
+func TestApiCallSelectNextNodeWhenTimeOut(t *testing.T) {
+	requestUrlHistory := make([]string, 0, 3)
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+		},
+	})
+	for _, server := range servers {
+		defer server.Close()
+	}
+
+	apiCall := NewApiCall(
+		&mockClient{},
+		&ClientConfig{
+			Nodes:             serverURLs,
+			ConnectionTimeout: 10 * time.Millisecond,
+		},
+	)
+	req := newHTTPRequest(t)
+
+	res, err := apiCall.Do(req)
+
+	assert.Error(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, serverURLs, requestUrlHistory)
+}
+func TestApiCallRemoveAndAddUnhealthyNodeIntoRotation(t *testing.T) {
+	requestUrlHistory := make([]string, 0, 8)
+	var count int
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			if count > 1 {
+				// will response sucessful after 2 failed request
+				w.WriteHeader(201)
+			} else {
+				count++
+				w.WriteHeader(500)
+			}
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(501)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(202)
+		},
+	})
+	for _, server := range servers {
+		defer server.Close()
+	}
+	defer func() {
+		apiCallTimeNow = time.Now
+	}()
+
+	apiCall := newApiCall(
+		&ClientConfig{
+			Nodes:               serverURLs,
+			HealthcheckInterval: 20 * time.Millisecond,
+			ConnectionTimeout:   5 * time.Second,
+		},
+	)
+	req := newHTTPRequest(t)
+
+	freezeUnixMilli(0)
+
+	res, err := apiCall.Do(req) // node 0 and node 1 will fail, node 2 will succeed
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res.StatusCode)
+	assert.Equal(t, serverURLs, requestUrlHistory[:3])
+
+	freezeUnixMilli(10)
+
+	res2, err := apiCall.Do(req) // request should still be made to node 2
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res2.StatusCode)
+	assert.Equal(t, serverURLs[2], requestUrlHistory[3])
+
+	freezeUnixMilli(25)
+
+	res3, err := apiCall.Do(req) // node 0 and 1 added back into rotation but still fail
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res3.StatusCode)
+	assert.Equal(t, serverURLs, requestUrlHistory[4:7])
+
+	freezeUnixMilli(50)
+
+	res4, err := apiCall.Do(req) // node 0 will succeed
+
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res4.StatusCode)
+	assert.Equal(t, serverURLs[0], requestUrlHistory[len(requestUrlHistory)-1])
+}
+
+// * When NearestNode is specified
+func TestApiCallWithNearestNode(t *testing.T) {
+	requestUrlHistory := make([]string, 0, 10)
+	var count int
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			if count > 1 {
+				// will response sucessful after 2 failed request
+				w.WriteHeader(201)
+			} else {
+				count++
+				w.WriteHeader(501)
+			}
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(502)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(503)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			requestUrlHistory = append(requestUrlHistory, "http://"+r.Host)
+			w.WriteHeader(202)
+		},
+	})
+	for _, server := range servers {
+		defer server.Close()
+	}
+	defer func() {
+		apiCallTimeNow = time.Now
+	}()
+
+	apiCall := newApiCall(
+		&ClientConfig{
+			NearestNode:         serverURLs[0],
+			Nodes:               serverURLs[1:],
+			HealthcheckInterval: 20 * time.Millisecond,
+			ConnectionTimeout:   5 * time.Second,
+		},
+	)
+
+	req := newHTTPRequest(t)
+
+	freezeUnixMilli(0)
+
+	res, err := apiCall.Do(req) // nearest node, node 0 and node 1 will fail, node 2 will succeed
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res.StatusCode)
+	assert.Equal(t, serverURLs, requestUrlHistory[:4])
+
+	freezeUnixMilli(10)
+
+	res2, err := apiCall.Do(req) // request should still be made to node 2
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res2.StatusCode)
+	assert.Equal(t, serverURLs[3], requestUrlHistory[4])
+
+	freezeUnixMilli(25)
+
+	res3, err := apiCall.Do(req) // nearest node, node 0 and 1 added back into rotation but still fail
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, res3.StatusCode)
+	assert.Equal(t, serverURLs, requestUrlHistory[5:9])
+
+	freezeUnixMilli(50)
+
+	res4, err := apiCall.Do(req) // nearest node will succeed
+
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res4.StatusCode)
+	assert.Equal(t, serverURLs[0], requestUrlHistory[9])
+
+	res5, err := apiCall.Do(req) // request should still be made to nearest node
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res5.StatusCode)
+	assert.Equal(t, serverURLs[0], requestUrlHistory[len(requestUrlHistory)-1])
+}
+
+func TestApiCallCompatibleWithServerURL(t *testing.T) {
+	var lastRequestURL string
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			lastRequestURL = "http://" + r.Host + r.RequestURI
+			w.WriteHeader(201)
+		},
+	})
+	defer servers[0].Close()
+
+	apiCall := newApiCall(
+		&ClientConfig{
+			ServerURL:         serverURLs[0],
+			ConnectionTimeout: 5 * time.Second,
+		},
+	)
+	req := newHTTPRequest(t, serverURLs[0]+"/collections/1?test=1")
+
+	res, err := apiCall.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+	assert.Equal(t, serverURLs[0]+"/collections/1?test=1", lastRequestURL)
+}
+
+func TestApiCallCanReplaceRequestHostName(t *testing.T) {
+	var lastRequestURL string
+
+	servers, serverURLs := instantiateServers([]serverHandler{
+		func(w http.ResponseWriter, r *http.Request) {
+			lastRequestURL = "http://" + r.Host + r.RequestURI
+		},
+	})
+	defer servers[0].Close()
+
+	apiCall := newApiCall(
+		&ClientConfig{
+			Nodes:             serverURLs,
+			ConnectionTimeout: 5 * time.Second,
+		},
+	)
+	req := newHTTPRequest(t)
+
+	res, err := apiCall.Do(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	assert.Equal(t, serverURLs[0]+"/collections/1?test=1", lastRequestURL)
+}

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -105,17 +105,17 @@ func WithServer(serverURL string) ClientOption {
 	}
 }
 
-// WithNodes sets multiple hostnames to load balance reads & writes across all nodes.
-func WithNodes(URLs []string) ClientOption {
-	return func(c *Client) {
-		c.apiConfig.Nodes = URLs
-	}
-}
-
 // WithNearestNode sets the Load Balanced endpoint.
 func WithNearestNode(URL string) ClientOption {
 	return func(c *Client) {
 		c.apiConfig.NearestNode = URL
+	}
+}
+
+// WithNodes sets multiple hostnames to load balance reads & writes across all nodes.
+func WithNodes(URLs []string) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.Nodes = URLs
 	}
 }
 

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -66,12 +66,19 @@ func (e *HTTPError) Error() string {
 }
 
 const (
-	defaultConnectionTimeout  = 5 * time.Second
-	defaultCircuitBreakerName = "typesenseClient"
+	defaultRetryInterval       = 100 * time.Millisecond
+	defaultHealthcheckInterval = 1 * time.Minute
+	defaultConnectionTimeout   = 5 * time.Second
+	defaultCircuitBreakerName  = "typesenseClient"
 )
 
 type ClientConfig struct {
 	ServerURL                   string
+	NearestNode                 string // optional
+	Nodes                       []string
+	NumRetries                  int
+	RetryInterval               time.Duration
+	HealthcheckInterval         time.Duration
 	APIKey                      string
 	ConnectionTimeout           time.Duration
 	CircuitBreakerName          string
@@ -95,6 +102,45 @@ func WithAPIClient(apiClient APIClientInterface) ClientOption {
 func WithServer(serverURL string) ClientOption {
 	return func(c *Client) {
 		c.apiConfig.ServerURL = serverURL
+	}
+}
+
+// WithNodes sets multiple hostnames to load balance reads & writes across all nodes.
+func WithNodes(URLs []string) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.Nodes = URLs
+	}
+}
+
+// WithNearestNode sets the Load Balanced endpoint.
+func WithNearestNode(URL string) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.NearestNode = URL
+	}
+}
+
+// WithNumRetries sets the number of retries per request.
+// Default value is the number of nodes (+1 if nearestNode is specified).
+func WithNumRetries(num int) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.NumRetries = num
+	}
+}
+
+// WithRetryInterval sets the wait time between each retry.
+// Default value is 100 milliseconds.
+func WithRetryInterval(duration time.Duration) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.RetryInterval = duration
+	}
+}
+
+// WithHealthcheckInterval sets the wait time for an unhealthy node to become healthy again.
+// A node is marked as unhealthy if its response status code is 5xx or has an error (e.g. timeout).
+// Default value is 1 minute.
+func WithHealthcheckInterval(duration time.Duration) ClientOption {
+	return func(c *Client) {
+		c.apiConfig.HealthcheckInterval = duration
 	}
 }
 
@@ -174,6 +220,11 @@ func WithCircuitBreakerOnStateChange(onStateChange circuit.GoBreakerOnStateChang
 func WithClientConfig(config *ClientConfig) ClientOption {
 	return func(c *Client) {
 		c.apiConfig.ServerURL = config.ServerURL
+		c.apiConfig.NearestNode = config.NearestNode
+		c.apiConfig.Nodes = config.Nodes
+		c.apiConfig.NumRetries = config.NumRetries
+		c.apiConfig.RetryInterval = config.RetryInterval
+		c.apiConfig.HealthcheckInterval = config.HealthcheckInterval
 		c.apiConfig.APIKey = config.APIKey
 		c.apiConfig.ConnectionTimeout = config.ConnectionTimeout
 		c.apiConfig.CircuitBreakerName = config.CircuitBreakerName
@@ -187,6 +238,8 @@ func WithClientConfig(config *ClientConfig) ClientOption {
 
 func NewClient(opts ...ClientOption) *Client {
 	c := &Client{apiConfig: &ClientConfig{
+		RetryInterval:             defaultRetryInterval,
+		HealthcheckInterval:       defaultHealthcheckInterval,
 		ConnectionTimeout:         defaultConnectionTimeout,
 		CircuitBreakerName:        defaultCircuitBreakerName,
 		CircuitBreakerMaxRequests: circuit.DefaultGoBreakerMaxRequests,
@@ -208,12 +261,29 @@ func NewClient(opts ...ClientOption) *Client {
 			circuit.WithGoBreakerOnStateChange(c.apiConfig.CircuitBreakerOnStateChange),
 		)
 		httpClient := circuit.NewHTTPClient(
-			circuit.WithHTTPRequestDoer(&http.Client{
-				Timeout: c.apiConfig.ConnectionTimeout,
-			}),
+			circuit.WithHTTPRequestDoer(
+				NewApiCall(
+					&http.Client{
+						Timeout: c.apiConfig.ConnectionTimeout,
+					},
+					c.apiConfig,
+				)),
 			circuit.WithCircuitBreaker(cb),
 		)
-		apiClient, _ := api.NewClientWithResponses(c.apiConfig.ServerURL,
+		serverURL := ""
+
+		switch {
+		case c.apiConfig.ServerURL != "":
+			serverURL = c.apiConfig.ServerURL
+		case c.apiConfig.NearestNode != "":
+			serverURL = c.apiConfig.NearestNode
+		default:
+			if len(c.apiConfig.Nodes) != 0 {
+				serverURL = c.apiConfig.Nodes[0]
+			}
+		}
+
+		apiClient, _ := api.NewClientWithResponses(serverURL,
 			api.WithAPIKey(c.apiConfig.APIKey),
 			api.WithHTTPClient(httpClient))
 		c.apiClient = apiClient

--- a/typesense/client_test.go
+++ b/typesense/client_test.go
@@ -41,6 +41,8 @@ func TestClientConfigOptions(t *testing.T) {
 			name:    "WithDefaultConfig",
 			options: []ClientOption{},
 			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, defaultRetryInterval, client.apiConfig.RetryInterval)
+				assert.Equal(t, defaultHealthcheckInterval, client.apiConfig.HealthcheckInterval)
 				assert.Equal(t, defaultConnectionTimeout, client.apiConfig.ConnectionTimeout)
 				assert.Equal(t, defaultCircuitBreakerName, client.apiConfig.CircuitBreakerName)
 				assert.Equal(t, circuit.DefaultGoBreakerMaxRequests, client.apiConfig.CircuitBreakerMaxRequests)
@@ -62,6 +64,58 @@ func TestClientConfigOptions(t *testing.T) {
 				assert.Equal(t, "http://example.com", client.apiConfig.ServerURL)
 				apiClient := getAPIClient(t, client.apiClient)
 				assert.Equal(t, "http://example.com/", apiClient.Server)
+			},
+		},
+		{
+			name: "WithNearestNode",
+			options: []ClientOption{
+				WithNearestNode("http://localhost:8108"),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, "http://localhost:8108", client.apiConfig.NearestNode)
+				apiClient := getAPIClient(t, client.apiClient)
+				assert.Equal(t, "http://localhost:8108/", apiClient.Server)
+			},
+		},
+		{
+			name: "WithNodes",
+			options: []ClientOption{
+				WithNodes([]string{"http://localhost:3000", "http://localhost:3001"}),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, []string{"http://localhost:3000", "http://localhost:3001"}, client.apiConfig.Nodes)
+				apiClient := getAPIClient(t, client.apiClient)
+				assert.Equal(t, "http://localhost:3000/", apiClient.Server)
+			},
+		},
+		{
+			name: "WithNumRetries",
+			options: []ClientOption{
+				WithNumRetries(10),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, 10, client.apiConfig.NumRetries)
+				assert.NotNil(t, client.apiClient)
+			},
+		},
+		{
+			name: "WithRetryInterval",
+			options: []ClientOption{
+				WithRetryInterval(10 * time.Second),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, 10*time.Second, client.apiConfig.RetryInterval)
+				assert.NotNil(t, client.apiClient)
+			},
+		},
+		{
+			name: "WithHealthcheckInterval",
+			options: []ClientOption{
+				WithHealthcheckInterval(10 * time.Second),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, 10*time.Second, client.apiConfig.HealthcheckInterval)
+				assert.NotNil(t, client.apiClient)
 			},
 		},
 		{


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Example

```go
client := typesense.NewClient(
		typesense.WithNearestNode("http://localhost:8108"),
		typesense.WithNodes([]string{"http://localhost:3000", "http://localhost:3001"}),
	)
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
