### PR TITLE
Add support for stopwords, metrics & stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,34 @@ client.Collection("products").Synonyms().Retrieve(context.Background())
 client.Collection("products").Synonym("coat-synonyms").Delete(context.Background())
 ```
 
+### Create or update a stopwords set
+
+```go
+	stopwords := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+	client.Stopwords().Upsert(context.Background(), "stopword_set1", stopwords)
+```
+
+### Retrieve a stopwords set
+
+```go
+client.Stopword("stopword_set1").Retrieve(context.Background())
+```
+
+### List all stopwords sets
+
+```go
+client.Stopwords().Retrieve(context.Background())
+```
+
+### Delete a stopwords set
+
+```go
+client.Stopword("stopword_set1").Delete(context.Background())
+```
+
 ### Create or update a preset
 
 ```go
@@ -443,6 +471,18 @@ client.Operations().Snapshot(context.Background(), "/tmp/typesense-data-snapshot
 
 ```go
 client.Operations().Vote(context.Background())
+```
+
+### Cluster Metrics
+
+```go
+client.Metrics().Retrieve(context.Background())
+```
+
+### API Stats
+
+```go
+client.Stats().Retrieve(context.Background())
 ```
 
 ## Contributing

--- a/typesense/api/client_gen.go
+++ b/typesense/api/client_gen.go
@@ -6016,7 +6016,7 @@ func (r UpsertPresetResponse) StatusCode() int {
 type RetrieveStopwordsSetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *StopwordsSetRetrieveSchema
+	JSON200      *StopwordsSetsRetrieveAllSchema
 }
 
 // Status returns HTTPResponse.Status
@@ -8089,7 +8089,7 @@ func ParseRetrieveStopwordsSetsResponse(rsp *http.Response) (*RetrieveStopwordsS
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest StopwordsSetRetrieveSchema
+		var dest StopwordsSetsRetrieveAllSchema
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -3,41 +3,43 @@ components:
     APIStatsResponse:
       properties:
         delete_latency_ms:
-          format: float
+          format: double
           type: number
         delete_requests_per_second:
-          format: float
+          format: double
           type: number
         import_latency_ms:
-          format: float
+          format: double
           type: number
         import_requests_per_second:
-          format: float
+          format: double
           type: number
         latency_ms:
           type: object
+          x-go-type: map[string]float64
         overloaded_requests_per_second:
-          format: float
+          format: double
           type: number
         pending_write_batches:
-          format: float
+          format: double
           type: number
         requests_per_second:
           type: object
+          x-go-type: map[string]float64
         search_latency_ms:
-          format: float
+          format: double
           type: number
         search_requests_per_second:
-          format: float
+          format: double
           type: number
         total_requests_per_second:
-          format: float
+          format: double
           type: number
         write_latency_ms:
-          format: float
+          format: double
           type: number
         write_requests_per_second:
-          format: float
+          format: double
           type: number
       type: object
     AnalyticsRuleParameters:
@@ -2553,6 +2555,20 @@ paths:
       summary: Retrieve (metadata about) a key
       tags:
         - keys
+  /metrics.json:
+    get:
+      description: Retrieve the metrics.
+      operationId: retrieveMetrics
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Metrics fetched.
+      summary: Get current RAM, CPU, Disk & Network usage metrics.
+      tags:
+        - operations
   /multi_search:
     post:
       description: This is especially useful to avoid round-trip network latencies incurred otherwise if each of these requests are sent in separate HTTP requests. You can also use this feature to do a federated search across multiple collections in a single HTTP request.
@@ -2950,7 +2966,7 @@ paths:
           description: Stats fetched.
       summary: Get stats about API endpoints.
       tags:
-        - stats
+        - operations
   /stopwords:
     get:
       description: Retrieve the details of all stopwords sets
@@ -3094,13 +3110,8 @@ tags:
   - description: Manage Typesense cluster
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/0.23.0/api/#cluster-operations
+      url: https://typesense.org/docs/26.0/api/cluster-operations.html
     name: operations
-  - description: Get stats about API endpoints.
-    externalDocs:
-      description: Find out more
-      url: https://typesense.org/docs/26.0/api/cluster-operations.html#api-stats
-    name: stats
   - description: Manage stopwords sets
     externalDocs:
       description: Find out more

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -1083,12 +1083,10 @@ components:
       type: object
     StopwordsSetRetrieveSchema:
       example: |
-        {"stopwords": [{"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}]}
+        {"stopwords": {"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}}
       properties:
         stopwords:
-          items:
-            $ref: '#/components/schemas/StopwordsSetSchema'
-          type: array
+          $ref: '#/components/schemas/StopwordsSetSchema'
       required:
         - stopwords
       type: object
@@ -1117,6 +1115,17 @@ components:
         stopwords:
           items:
             type: string
+          type: array
+      required:
+        - stopwords
+      type: object
+    StopwordsSetsRetrieveAllSchema:
+      example: |
+        {"stopwords": [{"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}]}
+      properties:
+        stopwords:
+          items:
+            $ref: '#/components/schemas/StopwordsSetSchema'
           type: array
       required:
         - stopwords
@@ -2897,7 +2906,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StopwordsSetRetrieveSchema'
+                $ref: '#/components/schemas/StopwordsSetsRetrieveAllSchema'
           description: Stopwords sets fetched.
       summary: Retrieves all stopwords sets.
       tags:

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -1,5 +1,45 @@
 components:
   schemas:
+    APIStatsResponse:
+      properties:
+        delete_latency_ms:
+          format: float
+          type: number
+        delete_requests_per_second:
+          format: float
+          type: number
+        import_latency_ms:
+          format: float
+          type: number
+        import_requests_per_second:
+          format: float
+          type: number
+        latency_ms:
+          type: object
+        overloaded_requests_per_second:
+          format: float
+          type: number
+        pending_write_batches:
+          format: float
+          type: number
+        requests_per_second:
+          type: object
+        search_latency_ms:
+          format: float
+          type: number
+        search_requests_per_second:
+          format: float
+          type: number
+        total_requests_per_second:
+          format: float
+          type: number
+        write_latency_ms:
+          format: float
+          type: number
+        write_requests_per_second:
+          format: float
+          type: number
+      type: object
     AnalyticsRuleParameters:
       properties:
         destination:
@@ -2897,6 +2937,20 @@ paths:
       summary: Upserts a preset.
       tags:
         - presets
+  /stats.json:
+    get:
+      description: Retrieve the stats about API endpoints.
+      operationId: retrieveAPIStats
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIStatsResponse'
+          description: Stats fetched.
+      summary: Get stats about API endpoints.
+      tags:
+        - stats
   /stopwords:
     get:
       description: Retrieve the details of all stopwords sets
@@ -3042,6 +3096,11 @@ tags:
       description: Find out more
       url: https://typesense.org/docs/0.23.0/api/#cluster-operations
     name: operations
+  - description: Get stats about API endpoints.
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/26.0/api/cluster-operations.html#api-stats
+    name: stats
   - description: Manage stopwords sets
     externalDocs:
       description: Find out more

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -41,6 +41,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://typesense.org/docs/0.23.0/api/#cluster-operations
+  - name: stats
+    description: Get stats about API endpoints.
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/26.0/api/cluster-operations.html#api-stats
   - name: stopwords
     description: Manage stopwords sets
     externalDocs:
@@ -1336,6 +1341,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
+  /stats.json:
+    get:
+      tags:
+        - stats
+      summary: Get stats about API endpoints.
+      description:
+        Retrieve the stats about API endpoints.
+      operationId: retrieveAPIStats
+      responses:
+        200:
+          description: Stats fetched.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIStatsResponse"
   /stopwords:
     get:
       tags:
@@ -2875,6 +2895,46 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AnalyticsRuleSchema"
+    APIStatsResponse:
+      type: object
+      properties:
+        delete_latency_ms:
+          type: number
+          format: float
+        delete_requests_per_second:
+          type: number
+          format: float
+        import_latency_ms:
+          type: number
+          format: float
+        import_requests_per_second:
+          type: number
+          format: float
+        latency_ms:
+          type: object
+        overloaded_requests_per_second:
+          type: number
+          format: float
+        pending_write_batches:
+          type: number
+          format: float
+        requests_per_second:
+          type: object
+        search_latency_ms:
+          type: number
+          format: float
+        search_requests_per_second:
+          type: number
+          format: float
+        total_requests_per_second:
+          type: number
+          format: float
+        write_latency_ms:
+          type: number
+          format: float
+        write_requests_per_second:
+          type: number
+          format: float
     StopwordsSetUpsertSchema:
       type: object
       properties:

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -40,12 +40,7 @@ tags:
     description: Manage Typesense cluster
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/0.23.0/api/#cluster-operations
-  - name: stats
-    description: Get stats about API endpoints.
-    externalDocs:
-      description: Find out more
-      url: https://typesense.org/docs/26.0/api/cluster-operations.html#api-stats
+      url: https://typesense.org/docs/26.0/api/cluster-operations.html
   - name: stopwords
     description: Manage stopwords sets
     externalDocs:
@@ -1341,10 +1336,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
+  /metrics.json:
+    get:
+      tags:
+        - operations
+      summary: Get current RAM, CPU, Disk & Network usage metrics.
+      description:
+        Retrieve the metrics.
+      operationId: retrieveMetrics
+      responses:
+        200:
+          description: Metrics fetched.
+          content:
+            application/json:
+              schema:
+                type: object
   /stats.json:
     get:
       tags:
-        - stats
+        - operations
       summary: Get stats about API endpoints.
       description:
         Retrieve the stats about API endpoints.
@@ -2900,41 +2910,43 @@ components:
       properties:
         delete_latency_ms:
           type: number
-          format: float
+          format: double
         delete_requests_per_second:
           type: number
-          format: float
+          format: double
         import_latency_ms:
           type: number
-          format: float
+          format: double
         import_requests_per_second:
           type: number
-          format: float
+          format: double
         latency_ms:
           type: object
+          x-go-type: "map[string]float64"
         overloaded_requests_per_second:
           type: number
-          format: float
+          format: double
         pending_write_batches:
           type: number
-          format: float
+          format: double
         requests_per_second:
           type: object
+          x-go-type: "map[string]float64"
         search_latency_ms:
           type: number
-          format: float
+          format: double
         search_requests_per_second:
           type: number
-          format: float
+          format: double
         total_requests_per_second:
           type: number
-          format: float
+          format: double
         write_latency_ms:
           type: number
-          format: float
+          format: double
         write_requests_per_second:
           type: number
-          format: float
+          format: double
     StopwordsSetUpsertSchema:
       type: object
       properties:

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -1350,7 +1350,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StopwordsSetRetrieveSchema"
+                $ref: "#/components/schemas/StopwordsSetsRetrieveAllSchema"
   /stopwords/{setId}:
     put:
       tags:
@@ -2905,6 +2905,15 @@ components:
       example: |
         {"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}
     StopwordsSetRetrieveSchema:
+      type: object
+      properties:
+        stopwords:
+          $ref: "#/components/schemas/StopwordsSetSchema"
+      required:
+        - stopwords
+      example: |
+        {"stopwords": {"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}}
+    StopwordsSetsRetrieveAllSchema:
       type: object
       properties:
         stopwords:

--- a/typesense/api/pointer/pointer.go
+++ b/typesense/api/pointer/pointer.go
@@ -10,6 +10,14 @@ func False() *bool {
 	return &res
 }
 
+func Float32(v float32) *float32 {
+	return &v
+}
+
+func Float64(v float64) *float64 {
+	return &v
+}
+
 func Int(v int) *int {
 	return &v
 }

--- a/typesense/api/pointer/pointer_test.go
+++ b/typesense/api/pointer/pointer_test.go
@@ -16,6 +16,14 @@ func TestPointerValues(t *testing.T) {
 	assert.NotNil(t, String("abc"))
 	assert.Equal(t, "abc", *String("abc"))
 
+	var expectedFloat32 float32 = 9.5
+	assert.NotNil(t, Float32(9.5))
+	assert.Equal(t, expectedFloat32, *Float32(9.5))
+
+	var expectedFloat64 float64 = 9.5
+	assert.NotNil(t, Float64(9.5))
+	assert.Equal(t, expectedFloat64, *Float64(9.5))
+
 	v := struct{ field string }{field: "abc"}
 	assert.NotNil(t, Interface(v))
 	assert.Equal(t, v, *Interface(v))

--- a/typesense/api/pointer/pointer_test.go
+++ b/typesense/api/pointer/pointer_test.go
@@ -20,9 +20,8 @@ func TestPointerValues(t *testing.T) {
 	assert.NotNil(t, Float32(9.5))
 	assert.Equal(t, expectedFloat32, *Float32(9.5))
 
-	var expectedFloat64 float64 = 9.5
 	assert.NotNil(t, Float64(9.5))
-	assert.Equal(t, expectedFloat64, *Float64(9.5))
+	assert.Equal(t, 9.5, *Float64(9.5))
 
 	v := struct{ field string }{field: "abc"}
 	assert.NotNil(t, Interface(v))

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -920,7 +920,7 @@ type SearchSynonymsResponse struct {
 
 // StopwordsSetRetrieveSchema defines model for StopwordsSetRetrieveSchema.
 type StopwordsSetRetrieveSchema struct {
-	Stopwords []StopwordsSetSchema `json:"stopwords"`
+	Stopwords StopwordsSetSchema `json:"stopwords"`
 }
 
 // StopwordsSetSchema defines model for StopwordsSetSchema.
@@ -934,6 +934,11 @@ type StopwordsSetSchema struct {
 type StopwordsSetUpsertSchema struct {
 	Locale    *string  `json:"locale,omitempty"`
 	Stopwords []string `json:"stopwords"`
+}
+
+// StopwordsSetsRetrieveAllSchema defines model for StopwordsSetsRetrieveAllSchema.
+type StopwordsSetsRetrieveAllSchema struct {
+	Stopwords []StopwordsSetSchema `json:"stopwords"`
 }
 
 // SuccessStatus defines model for SuccessStatus.

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -32,6 +32,23 @@ const (
 	Reject         ImportDocumentsParamsDirtyValues = "reject"
 )
 
+// APIStatsResponse defines model for APIStatsResponse.
+type APIStatsResponse struct {
+	DeleteLatencyMs             *float32                `json:"delete_latency_ms,omitempty"`
+	DeleteRequestsPerSecond     *float32                `json:"delete_requests_per_second,omitempty"`
+	ImportLatencyMs             *float32                `json:"import_latency_ms,omitempty"`
+	ImportRequestsPerSecond     *float32                `json:"import_requests_per_second,omitempty"`
+	LatencyMs                   *map[string]interface{} `json:"latency_ms,omitempty"`
+	OverloadedRequestsPerSecond *float32                `json:"overloaded_requests_per_second,omitempty"`
+	PendingWriteBatches         *float32                `json:"pending_write_batches,omitempty"`
+	RequestsPerSecond           *map[string]interface{} `json:"requests_per_second,omitempty"`
+	SearchLatencyMs             *float32                `json:"search_latency_ms,omitempty"`
+	SearchRequestsPerSecond     *float32                `json:"search_requests_per_second,omitempty"`
+	TotalRequestsPerSecond      *float32                `json:"total_requests_per_second,omitempty"`
+	WriteLatencyMs              *float32                `json:"write_latency_ms,omitempty"`
+	WriteRequestsPerSecond      *float32                `json:"write_requests_per_second,omitempty"`
+}
+
 // AnalyticsRuleParameters defines model for AnalyticsRuleParameters.
 type AnalyticsRuleParameters struct {
 	Destination struct {

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -34,19 +34,19 @@ const (
 
 // APIStatsResponse defines model for APIStatsResponse.
 type APIStatsResponse struct {
-	DeleteLatencyMs             *float32                `json:"delete_latency_ms,omitempty"`
-	DeleteRequestsPerSecond     *float32                `json:"delete_requests_per_second,omitempty"`
-	ImportLatencyMs             *float32                `json:"import_latency_ms,omitempty"`
-	ImportRequestsPerSecond     *float32                `json:"import_requests_per_second,omitempty"`
-	LatencyMs                   *map[string]interface{} `json:"latency_ms,omitempty"`
-	OverloadedRequestsPerSecond *float32                `json:"overloaded_requests_per_second,omitempty"`
-	PendingWriteBatches         *float32                `json:"pending_write_batches,omitempty"`
-	RequestsPerSecond           *map[string]interface{} `json:"requests_per_second,omitempty"`
-	SearchLatencyMs             *float32                `json:"search_latency_ms,omitempty"`
-	SearchRequestsPerSecond     *float32                `json:"search_requests_per_second,omitempty"`
-	TotalRequestsPerSecond      *float32                `json:"total_requests_per_second,omitempty"`
-	WriteLatencyMs              *float32                `json:"write_latency_ms,omitempty"`
-	WriteRequestsPerSecond      *float32                `json:"write_requests_per_second,omitempty"`
+	DeleteLatencyMs             *float64            `json:"delete_latency_ms,omitempty"`
+	DeleteRequestsPerSecond     *float64            `json:"delete_requests_per_second,omitempty"`
+	ImportLatencyMs             *float64            `json:"import_latency_ms,omitempty"`
+	ImportRequestsPerSecond     *float64            `json:"import_requests_per_second,omitempty"`
+	LatencyMs                   *map[string]float64 `json:"latency_ms,omitempty"`
+	OverloadedRequestsPerSecond *float64            `json:"overloaded_requests_per_second,omitempty"`
+	PendingWriteBatches         *float64            `json:"pending_write_batches,omitempty"`
+	RequestsPerSecond           *map[string]float64 `json:"requests_per_second,omitempty"`
+	SearchLatencyMs             *float64            `json:"search_latency_ms,omitempty"`
+	SearchRequestsPerSecond     *float64            `json:"search_requests_per_second,omitempty"`
+	TotalRequestsPerSecond      *float64            `json:"total_requests_per_second,omitempty"`
+	WriteLatencyMs              *float64            `json:"write_latency_ms,omitempty"`
+	WriteRequestsPerSecond      *float64            `json:"write_requests_per_second,omitempty"`
 }
 
 // AnalyticsRuleParameters defines model for AnalyticsRuleParameters.

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -72,6 +72,10 @@ func (c *Client) Stopword(stopwordsSetId string) StopwordInterface {
 	return &stopword{apiClient: c.apiClient, stopwordsSetId: stopwordsSetId}
 }
 
+func (c *Client) Stats() StatsInterface {
+	return &stats{apiClient: c.apiClient}
+}
+
 type HTTPError struct {
 	Status int
 	Body   []byte

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -76,6 +76,10 @@ func (c *Client) Stats() StatsInterface {
 	return &stats{apiClient: c.apiClient}
 }
 
+func (c *Client) Metrics() MetricsInterface {
+	return &metrics{apiClient: c.apiClient}
+}
+
 type HTTPError struct {
 	Status int
 	Body   []byte

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -68,6 +68,10 @@ func (c *Client) Stopwords() StopwordsInterface {
 	return &stopwords{apiClient: c.apiClient}
 }
 
+func (c *Client) Stopword(stopwordsSetId string) StopwordInterface {
+	return &stopword{apiClient: c.apiClient, stopwordsSetId: stopwordsSetId}
+}
+
 type HTTPError struct {
 	Status int
 	Body   []byte

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -64,6 +64,10 @@ func (c *Client) Preset(presetName string) PresetInterface {
 	return &preset{apiClient: c.apiClient, presetName: presetName}
 }
 
+func (c *Client) Stopwords() StopwordsInterface {
+	return &stopwords{apiClient: c.apiClient}
+}
+
 type HTTPError struct {
 	Status int
 	Body   []byte

--- a/typesense/metrics.go
+++ b/typesense/metrics.go
@@ -1,0 +1,24 @@
+package typesense
+
+import (
+	"context"
+)
+
+type MetricsInterface interface {
+	Retrieve(ctx context.Context) (map[string]interface{}, error)
+}
+
+type metrics struct {
+	apiClient APIClientInterface
+}
+
+func (m *metrics) Retrieve(ctx context.Context) (map[string]interface{}, error) {
+	response, err := m.apiClient.RetrieveMetricsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return *response.JSON200, nil
+}

--- a/typesense/metrics_test.go
+++ b/typesense/metrics_test.go
@@ -1,0 +1,57 @@
+package typesense
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsRetrieve(t *testing.T) {
+	expectedData := map[string]interface{}{
+		"system_cpu1_active_percentage":        "0.00",
+		"system_cpu2_active_percentage":        "0.00",
+		"system_cpu3_active_percentage":        "0.00",
+		"system_cpu4_active_percentage":        "0.00",
+		"system_cpu_active_percentage":         "0.00",
+		"system_disk_total_bytes":              "1043447808",
+		"system_disk_used_bytes":               "561152",
+		"system_memory_total_bytes":            "2086899712",
+		"system_memory_used_bytes":             "1004507136",
+		"system_memory_total_swap_bytes":       "1004507136",
+		"system_memory_used_swap_bytes":        "0.00",
+		"system_network_received_bytes":        "1466",
+		"system_network_sent_bytes":            "182",
+		"typesense_memory_active_bytes":        "29630464",
+		"typesense_memory_allocated_bytes":     "27886840",
+		"typesense_memory_fragmentation_ratio": "0.06",
+		"typesense_memory_mapped_bytes":        "69701632",
+		"typesense_memory_metadata_bytes":      "4588768",
+		"typesense_memory_resident_bytes":      "29630464",
+		"typesense_memory_retained_bytes":      "25718784",
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/metrics.json", http.MethodGet)
+		data := jsonEncode(t, expectedData)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Metrics().Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestMetricsRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/metrics.json", http.MethodGet)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Metrics().Retrieve(context.Background())
+	assert.ErrorContains(t, err, "status: 409")
+}

--- a/typesense/mocks/mock_client.go
+++ b/typesense/mocks/mock_client.go
@@ -1602,6 +1602,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAnalyticsRulesWithResponse
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAnalyticsRulesWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAnalyticsRulesWithResponse), varargs...)
 }
 
+// RetrieveMetrics mocks base method.
+func (m *MockAPIClientInterface) RetrieveMetrics(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveMetrics", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveMetrics indicates an expected call of RetrieveMetrics.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveMetrics(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveMetrics", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveMetrics), varargs...)
+}
+
+// RetrieveMetricsWithResponse mocks base method.
+func (m *MockAPIClientInterface) RetrieveMetricsWithResponse(ctx context.Context, reqEditors ...api.RequestEditorFn) (*api.RetrieveMetricsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveMetricsWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RetrieveMetricsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveMetricsWithResponse indicates an expected call of RetrieveMetricsWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveMetricsWithResponse(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveMetricsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveMetricsWithResponse), varargs...)
+}
+
 // RetrievePreset mocks base method.
 func (m *MockAPIClientInterface) RetrievePreset(ctx context.Context, presetId string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()

--- a/typesense/mocks/mock_client.go
+++ b/typesense/mocks/mock_client.go
@@ -1442,6 +1442,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) MultiSearchWithResponse(ctx, param
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiSearchWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).MultiSearchWithResponse), varargs...)
 }
 
+// RetrieveAPIStats mocks base method.
+func (m *MockAPIClientInterface) RetrieveAPIStats(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveAPIStats", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveAPIStats indicates an expected call of RetrieveAPIStats.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAPIStats(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAPIStats", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAPIStats), varargs...)
+}
+
+// RetrieveAPIStatsWithResponse mocks base method.
+func (m *MockAPIClientInterface) RetrieveAPIStatsWithResponse(ctx context.Context, reqEditors ...api.RequestEditorFn) (*api.RetrieveAPIStatsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveAPIStatsWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RetrieveAPIStatsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveAPIStatsWithResponse indicates an expected call of RetrieveAPIStatsWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAPIStatsWithResponse(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAPIStatsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAPIStatsWithResponse), varargs...)
+}
+
 // RetrieveAllPresets mocks base method.
 func (m *MockAPIClientInterface) RetrieveAllPresets(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()

--- a/typesense/stats.go
+++ b/typesense/stats.go
@@ -1,0 +1,26 @@
+package typesense
+
+import (
+	"context"
+
+	"github.com/typesense/typesense-go/typesense/api"
+)
+
+type StatsInterface interface {
+	Retrieve(ctx context.Context) (*api.APIStatsResponse, error)
+}
+
+type stats struct {
+	apiClient APIClientInterface
+}
+
+func (s *stats) Retrieve(ctx context.Context) (*api.APIStatsResponse, error) {
+	response, err := s.apiClient.RetrieveAPIStatsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response.JSON200, nil
+}

--- a/typesense/stats.go
+++ b/typesense/stats.go
@@ -3,7 +3,7 @@ package typesense
 import (
 	"context"
 
-	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api"
 )
 
 type StatsInterface interface {

--- a/typesense/stats_test.go
+++ b/typesense/stats_test.go
@@ -1,0 +1,56 @@
+package typesense
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/typesense/api/pointer"
+)
+
+func TestStatsRetrieve(t *testing.T) {
+	expectedData := &api.APIStatsResponse{
+		DeleteLatencyMs:         pointer.Float32(10.5),
+		DeleteRequestsPerSecond: pointer.Float32(5.0),
+		ImportLatencyMs:         pointer.Float32(9.5),
+		ImportRequestsPerSecond: pointer.Float32(9.5),
+		LatencyMs: &map[string]interface{}{
+			"GET /stats.json": 0.0,
+		},
+		OverloadedRequestsPerSecond: pointer.Float32(9.5),
+		PendingWriteBatches:         pointer.Float32(9.5),
+		RequestsPerSecond: &map[string]interface{}{
+			"GET /stats.json": pointer.Float32(3.3),
+		},
+		SearchLatencyMs:         pointer.Float32(9.5),
+		SearchRequestsPerSecond: pointer.Float32(9.5),
+		TotalRequestsPerSecond:  pointer.Float32(3.3),
+		WriteLatencyMs:          pointer.Float32(9.5),
+		WriteRequestsPerSecond:  pointer.Float32(9.5),
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stats.json", http.MethodGet)
+		data := jsonEncode(t, expectedData)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Stats().Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestStatsRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stats.json", http.MethodGet)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Stats().Retrieve(context.Background())
+	assert.ErrorContains(t, err, "status: 409")
+}

--- a/typesense/stats_test.go
+++ b/typesense/stats_test.go
@@ -12,23 +12,23 @@ import (
 
 func TestStatsRetrieve(t *testing.T) {
 	expectedData := &api.APIStatsResponse{
-		DeleteLatencyMs:         pointer.Float32(10.5),
-		DeleteRequestsPerSecond: pointer.Float32(5.0),
-		ImportLatencyMs:         pointer.Float32(9.5),
-		ImportRequestsPerSecond: pointer.Float32(9.5),
-		LatencyMs: &map[string]interface{}{
-			"GET /stats.json": 0.0,
+		DeleteLatencyMs:         pointer.Float64(10.5),
+		DeleteRequestsPerSecond: pointer.Float64(5.0),
+		ImportLatencyMs:         pointer.Float64(3.7142857142857144),
+		ImportRequestsPerSecond: pointer.Float64(9.5),
+		LatencyMs: &map[string]float64{
+			"GET /stats.json": *pointer.Float64(32.5),
 		},
-		OverloadedRequestsPerSecond: pointer.Float32(9.5),
-		PendingWriteBatches:         pointer.Float32(9.5),
-		RequestsPerSecond: &map[string]interface{}{
-			"GET /stats.json": pointer.Float32(3.3),
+		OverloadedRequestsPerSecond: pointer.Float64(9.5),
+		PendingWriteBatches:         pointer.Float64(9.5),
+		RequestsPerSecond: &map[string]float64{
+			"GET /stats.json": *pointer.Float64(0.1111111111111111),
 		},
-		SearchLatencyMs:         pointer.Float32(9.5),
-		SearchRequestsPerSecond: pointer.Float32(9.5),
-		TotalRequestsPerSecond:  pointer.Float32(3.3),
-		WriteLatencyMs:          pointer.Float32(9.5),
-		WriteRequestsPerSecond:  pointer.Float32(9.5),
+		SearchLatencyMs:         pointer.Float64(9.5),
+		SearchRequestsPerSecond: pointer.Float64(9.5),
+		TotalRequestsPerSecond:  pointer.Float64(3.3),
+		WriteLatencyMs:          pointer.Float64(9.5),
+		WriteRequestsPerSecond:  pointer.Float64(9.5),
 	}
 
 	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {

--- a/typesense/stats_test.go
+++ b/typesense/stats_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/typesense/typesense-go/typesense/api"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
+	"github.com/typesense/typesense-go/v2/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api/pointer"
 )
 
 func TestStatsRetrieve(t *testing.T) {

--- a/typesense/stopword.go
+++ b/typesense/stopword.go
@@ -1,0 +1,43 @@
+package typesense
+
+import (
+	"context"
+
+	"github.com/typesense/typesense-go/typesense/api"
+)
+
+type StopwordInterface interface {
+	Retrieve(ctx context.Context) (*api.StopwordsSetSchema, error)
+	Delete(ctx context.Context) (*struct {
+		Id string "json:\"id\""
+	}, error)
+}
+
+type stopword struct {
+	apiClient      APIClientInterface
+	stopwordsSetId string
+}
+
+func (s *stopword) Retrieve(ctx context.Context) (*api.StopwordsSetSchema, error) {
+	response, err := s.apiClient.RetrieveStopwordsSetWithResponse(ctx, s.stopwordsSetId)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return &response.JSON200.Stopwords, nil
+}
+
+func (s *stopword) Delete(ctx context.Context) (*struct {
+	Id string "json:\"id\""
+}, error) {
+	response, err := s.apiClient.DeleteStopwordsSetWithResponse(ctx, s.stopwordsSetId)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response.JSON200, nil
+}

--- a/typesense/stopword.go
+++ b/typesense/stopword.go
@@ -3,7 +3,7 @@ package typesense
 import (
 	"context"
 
-	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api"
 )
 
 type StopwordInterface interface {

--- a/typesense/stopword_test.go
+++ b/typesense/stopword_test.go
@@ -1,0 +1,75 @@
+package typesense
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/typesense/api/pointer"
+)
+
+func TestStopwordRetrieve(t *testing.T) {
+	expectedData := &api.StopwordsSetSchema{
+		Id:        "stopwords_set1",
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodGet)
+		data := jsonEncode(t, map[string]any{
+			"stopwords": expectedData,
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Stopword(expectedData.Id).Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestStopwordRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodGet)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Stopword("stopwords_set1").Retrieve(context.Background())
+	assert.ErrorContains(t, err, "status: 409")
+}
+
+func TestStopwordDelete(t *testing.T) {
+	expectedData := &struct {
+		Id string "json:\"id\""
+	}{
+		Id: "stopwords_set1",
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodDelete)
+		data := jsonEncode(t, expectedData)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Stopword(expectedData.Id).Delete(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestStopwordDeleteOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodDelete)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Stopword("stopwords_set1").Delete(context.Background())
+	assert.ErrorContains(t, err, "status: 409")
+}

--- a/typesense/stopword_test.go
+++ b/typesense/stopword_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/typesense/typesense-go/typesense/api"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
+	"github.com/typesense/typesense-go/v2/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api/pointer"
 )
 
 func TestStopwordRetrieve(t *testing.T) {

--- a/typesense/stopwords.go
+++ b/typesense/stopwords.go
@@ -15,8 +15,8 @@ type stopwords struct {
 	apiClient APIClientInterface
 }
 
-func (p *stopwords) Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, error) {
-	response, err := p.apiClient.RetrieveStopwordsSetsWithResponse(ctx)
+func (s *stopwords) Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, error) {
+	response, err := s.apiClient.RetrieveStopwordsSetsWithResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -26,8 +26,8 @@ func (p *stopwords) Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, err
 	return response.JSON200.Stopwords, nil
 }
 
-func (p *stopwords) Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error) {
-	response, err := p.apiClient.UpsertStopwordsSetWithResponse(ctx, stopwordsSetId, *stopwordssetUpsertSchema)
+func (s *stopwords) Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error) {
+	response, err := s.apiClient.UpsertStopwordsSetWithResponse(ctx, stopwordsSetId, *stopwordssetUpsertSchema)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/stopwords.go
+++ b/typesense/stopwords.go
@@ -1,0 +1,38 @@
+package typesense
+
+import (
+	"context"
+
+	"github.com/typesense/typesense-go/typesense/api"
+)
+
+type StopwordsInterface interface {
+	Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, error)
+	Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error)
+}
+
+type stopwords struct {
+	apiClient APIClientInterface
+}
+
+func (p *stopwords) Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, error) {
+	response, err := p.apiClient.RetrieveStopwordsSetsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response.JSON200.Stopwords, nil
+}
+
+func (p *stopwords) Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error) {
+	response, err := p.apiClient.UpsertStopwordsSetWithResponse(ctx, stopwordsSetId, *stopwordssetUpsertSchema)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response.JSON200, nil
+}

--- a/typesense/stopwords.go
+++ b/typesense/stopwords.go
@@ -8,7 +8,7 @@ import (
 
 type StopwordsInterface interface {
 	Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, error)
-	Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error)
+	Upsert(ctx context.Context, stopwordsSetId string, stopwordsSetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error)
 }
 
 type stopwords struct {
@@ -26,8 +26,8 @@ func (s *stopwords) Retrieve(ctx context.Context) ([]api.StopwordsSetSchema, err
 	return response.JSON200.Stopwords, nil
 }
 
-func (s *stopwords) Upsert(ctx context.Context, stopwordsSetId string, stopwordssetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error) {
-	response, err := s.apiClient.UpsertStopwordsSetWithResponse(ctx, stopwordsSetId, *stopwordssetUpsertSchema)
+func (s *stopwords) Upsert(ctx context.Context, stopwordsSetId string, stopwordsSetUpsertSchema *api.StopwordsSetUpsertSchema) (*api.StopwordsSetSchema, error) {
+	response, err := s.apiClient.UpsertStopwordsSetWithResponse(ctx, stopwordsSetId, *stopwordsSetUpsertSchema)
 	if err != nil {
 		return nil, err
 	}

--- a/typesense/stopwords.go
+++ b/typesense/stopwords.go
@@ -3,7 +3,7 @@ package typesense
 import (
 	"context"
 
-	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api"
 )
 
 type StopwordsInterface interface {

--- a/typesense/stopwords_test.go
+++ b/typesense/stopwords_test.go
@@ -1,0 +1,92 @@
+package typesense
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/typesense/api/pointer"
+)
+
+func TestStopwordsRetrieve(t *testing.T) {
+	expectedData := []api.StopwordsSetSchema{
+		{
+			Id:        "stopwords_set1",
+			Locale:    pointer.String("en"),
+			Stopwords: []string{"Germany", "France", "Italy", "United States"},
+		},
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords", http.MethodGet)
+		data := jsonEncode(t, map[string][]api.StopwordsSetSchema{
+			"stopwords": expectedData,
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Stopwords().Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestStopwordsRetrieveOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords", http.MethodGet)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Stopwords().Retrieve(context.Background())
+	assert.ErrorContains(t, err, "status: 409")
+}
+
+func TestStopwordsUpsert(t *testing.T) {
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	expectedData := &api.StopwordsSetSchema{
+		Id:        "stopwords_set1",
+		Locale:    upsertData.Locale,
+		Stopwords: upsertData.Stopwords,
+	}
+
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodPut)
+
+		var reqBody api.StopwordsSetUpsertSchema
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *upsertData, reqBody)
+
+		data := jsonEncode(t, expectedData)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
+	defer server.Close()
+
+	res, err := client.Stopwords().Upsert(context.Background(), "stopwords_set1", upsertData)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, res)
+}
+
+func TestStopwordsUpsertOnHttpStatusErrorCodeReturnsError(t *testing.T) {
+	server, client := newTestServerAndClient(func(w http.ResponseWriter, r *http.Request) {
+		validateRequestMetadata(t, r, "/stopwords/stopwords_set1", http.MethodPut)
+		w.WriteHeader(http.StatusConflict)
+	})
+	defer server.Close()
+
+	_, err := client.Stopwords().Upsert(context.Background(), "stopwords_set1", &api.StopwordsSetUpsertSchema{})
+	assert.ErrorContains(t, err, "status: 409")
+}

--- a/typesense/stopwords_test.go
+++ b/typesense/stopwords_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/typesense/typesense-go/typesense/api"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
+	"github.com/typesense/typesense-go/v2/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api/pointer"
 )
 
 func TestStopwordsRetrieve(t *testing.T) {

--- a/typesense/test/metrics_test.go
+++ b/typesense/test/metrics_test.go
@@ -1,0 +1,17 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsRetrieve(t *testing.T) {
+	result, err := typesenseClient.Metrics().Retrieve(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result["system_memory_total_bytes"])
+}

--- a/typesense/test/multi_search_test.go
+++ b/typesense/test/multi_search_test.go
@@ -27,23 +27,24 @@ func TestMultiSearch(t *testing.T) {
 	_, err := typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
-	_, err = typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
+	_, err = typesenseClient.Collection(collectionName2).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searchParams := &api.MultiSearchParams{
 		FilterBy: pointer.String("num_employees:>100"),
-		Q:        pointer.String("Company"),
 		QueryBy:  pointer.String("company_name"),
 	}
 
 	searches := api.MultiSearchSearchesParameter{
 		Searches: []api.MultiSearchCollectionParameters{
 			{
+				Q:          pointer.String("Company"),
 				Collection: collectionName1,
 				FilterBy:   pointer.String("num_employees:>100"),
 				SortBy:     pointer.String("num_employees:desc"),
 			},
 			{
+				Q:          pointer.String("Company"),
 				Collection: collectionName1,
 				FilterBy:   pointer.String("num_employees:>1000"),
 			},
@@ -70,6 +71,7 @@ func TestMultiSearch(t *testing.T) {
 	require.Equal(t, 3, len(result.Results))
 
 	// Check first result
+	require.Equal(t, len(expectedDocs1), len(*result.Results[0].Hits), "Number of docs in first result did not equal")
 	for i, doc := range *result.Results[0].Hits {
 		require.Equal(t, *doc.Document, expectedDocs1[i])
 	}
@@ -78,6 +80,7 @@ func TestMultiSearch(t *testing.T) {
 	require.Equal(t, 0, len(*result.Results[1].Hits))
 
 	// Check third result
+	require.Equal(t, len(expectedDocs2), len(*result.Results[2].Hits), "Number of docs in third result did not equal")
 	for i, doc := range *result.Results[2].Hits {
 		require.Equal(t, *doc.Document, expectedDocs2[i])
 	}
@@ -208,17 +211,19 @@ func TestMultiSearchWithPreset(t *testing.T) {
 	_, err := typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
-	_, err = typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
+	_, err = typesenseClient.Collection(collectionName2).Documents().Import(context.Background(), documents, params)
 	require.NoError(t, err)
 
 	searches := api.MultiSearchSearchesParameter{
 		Searches: []api.MultiSearchCollectionParameters{
 			{
+				Q:          pointer.String("Company"),
 				Collection: collectionName1,
 				FilterBy:   pointer.String("num_employees:>100"),
 				SortBy:     pointer.String("num_employees:desc"),
 			},
 			{
+				Q:          pointer.String("Company"),
 				Collection: collectionName1,
 				FilterBy:   pointer.String("num_employees:>1000"),
 			},
@@ -239,7 +244,6 @@ func TestMultiSearchWithPreset(t *testing.T) {
 
 	searchParams := &api.MultiSearchParams{
 		FilterBy: pointer.String("num_employees:>100"),
-		Q:        pointer.String("Company"),
 		QueryBy:  pointer.String("company_name"),
 		Preset:   &presetName,
 	}
@@ -259,6 +263,7 @@ func TestMultiSearchWithPreset(t *testing.T) {
 	require.Equal(t, 3, len(result.Results))
 
 	// Check first result
+	require.Equal(t, len(expectedDocs1), len(*result.Results[0].Hits), "Number of docs in first result did not equal")
 	for i, doc := range *result.Results[0].Hits {
 		require.Equal(t, *doc.Document, expectedDocs1[i])
 	}
@@ -267,6 +272,7 @@ func TestMultiSearchWithPreset(t *testing.T) {
 	require.Equal(t, 0, len(*result.Results[1].Hits))
 
 	// Check third result
+	require.Equal(t, len(expectedDocs2), len(*result.Results[2].Hits), "Number of docs in third result did not equal")
 	for i, doc := range *result.Results[2].Hits {
 		require.Equal(t, *doc.Document, expectedDocs2[i])
 	}

--- a/typesense/test/multi_search_test.go
+++ b/typesense/test/multi_search_test.go
@@ -271,3 +271,72 @@ func TestMultiSearchWithPreset(t *testing.T) {
 		require.Equal(t, *doc.Document, expectedDocs2[i])
 	}
 }
+
+func TestMultiSearchWithStopwords(t *testing.T) {
+	collectionName1 := createNewCollection(t, "companies")
+	collectionName2 := createNewCollection(t, "companies")
+	documents := []interface{}{
+		newDocument("123", withCompanyName("Company 1"), withNumEmployees(50)),
+		newDocument("125", withCompanyName("Company 2"), withNumEmployees(150)),
+		newDocument("127", withCompanyName("Company Stark Industries 3"), withNumEmployees(1000)),
+		newDocument("129", withCompanyName("Stark Industries 4"), withNumEmployees(1500)),
+	}
+
+	params := &api.ImportDocumentsParams{Action: pointer.String("create")}
+	_, err := typesenseClient.Collection(collectionName1).Documents().Import(context.Background(), documents, params)
+	require.NoError(t, err)
+
+	_, err = typesenseClient.Collection(collectionName2).Documents().Import(context.Background(), documents, params)
+	require.NoError(t, err)
+
+	stopwordsSetID := newUUIDName("stopwordsSet-test")
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Stark Industries"},
+	}
+
+	_, err = typesenseClient.Stopwords().Upsert(context.Background(), stopwordsSetID, upsertData)
+	require.NoError(t, err)
+
+	searchParams := &api.MultiSearchParams{
+		QueryBy:   pointer.String("company_name"),
+		Stopwords: pointer.String(stopwordsSetID),
+	}
+
+	searches := api.MultiSearchSearchesParameter{
+		Searches: []api.MultiSearchCollectionParameters{
+			{
+				Q:          pointer.String("Company Stark"),
+				Collection: collectionName1,
+				SortBy:     pointer.String("num_employees:desc"),
+			},
+			{
+				Q:          pointer.String("Stark"),
+				Collection: collectionName2,
+			},
+		},
+	}
+
+	expectedDocs1 := []map[string]interface{}{
+		newDocumentResponse("127", withResponseCompanyName("Company Stark Industries 3"),
+			withResponseNumEmployees(1000)),
+		newDocumentResponse("125", withResponseCompanyName("Company 2"),
+			withResponseNumEmployees(150)),
+		newDocumentResponse("123", withResponseCompanyName("Company 1"),
+			withResponseNumEmployees(50)),
+	}
+
+	result, err := typesenseClient.MultiSearch.Perform(context.Background(), searchParams, searches)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(result.Results))
+
+	// Check first result
+	require.Equal(t, len(expectedDocs1), len(*result.Results[0].Hits), "Number of docs in first result did not equal")
+	for i, doc := range *result.Results[0].Hits {
+		require.Equal(t, *doc.Document, expectedDocs1[i])
+	}
+
+	// Check second result
+	require.Equal(t, 0, len(*result.Results[1].Hits), "Number of docs in second result did not equal")
+}

--- a/typesense/test/stats_test.go
+++ b/typesense/test/stats_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsRetrieve(t *testing.T) {
+	_, err := typesenseClient.Stats().Retrieve(context.Background())
+	require.NoError(t, err)
+}

--- a/typesense/test/stopword_test.go
+++ b/typesense/test/stopword_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/typesense/api/pointer"
+)
+
+func TestStopwordRetrieve(t *testing.T) {
+	stopwordsSetID := newUUIDName("stopwordsSet-test")
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	expectedData := &api.StopwordsSetSchema{
+		Id:        stopwordsSetID,
+		Locale:    upsertData.Locale,
+		Stopwords: upsertData.Stopwords,
+	}
+
+	result, err := typesenseClient.Stopwords().Upsert(context.Background(), stopwordsSetID, upsertData)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedData, result)
+
+	result, err = typesenseClient.Stopword(stopwordsSetID).Retrieve(context.Background())
+
+	expectedData.Stopwords = []string{"states", "united", "france", "germany", "italy"}
+
+	require.NoError(t, err)
+	require.Equal(t, expectedData, result)
+}
+
+func TestStopwordDelete(t *testing.T) {
+	stopwordsSetID := newUUIDName("stopwordsSet-test")
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	expectedData := &api.StopwordsSetSchema{
+		Id:        stopwordsSetID,
+		Locale:    upsertData.Locale,
+		Stopwords: upsertData.Stopwords,
+	}
+
+	result, err := typesenseClient.Stopwords().Upsert(context.Background(), stopwordsSetID, upsertData)
+	require.NoError(t, err)
+	require.Equal(t, expectedData, result)
+
+	result2, err := typesenseClient.Stopword(stopwordsSetID).Delete(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, stopwordsSetID, result2.Id)
+
+	_, err = typesenseClient.Stopword(stopwordsSetID).Retrieve(context.Background())
+	require.Error(t, err)
+}

--- a/typesense/test/stopword_test.go
+++ b/typesense/test/stopword_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/typesense/typesense-go/typesense/api"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
+	"github.com/typesense/typesense-go/v2/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api/pointer"
 )
 
 func TestStopwordRetrieve(t *testing.T) {

--- a/typesense/test/stopwords_test.go
+++ b/typesense/test/stopwords_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense/api"
+	"github.com/typesense/typesense-go/typesense/api/pointer"
+)
+
+func TestStopwordsUpsert(t *testing.T) {
+	stopwordsSetID := newUUIDName("stopwordsSet-test")
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	expectedData := &api.StopwordsSetSchema{
+		Id:        stopwordsSetID,
+		Locale:    upsertData.Locale,
+		Stopwords: upsertData.Stopwords,
+	}
+
+	result, err := typesenseClient.Stopwords().Upsert(context.Background(), stopwordsSetID, upsertData)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedData, result)
+}
+
+func TestStopwordsRetrieve(t *testing.T) {
+	total := 3
+	stopwordsSetIDs := make([]string, total)
+	for i := 0; i < total; i++ {
+		stopwordsSetIDs[i] = newUUIDName("stopwordsSet-test")
+	}
+
+	upsertData := &api.StopwordsSetUpsertSchema{
+		Locale:    pointer.String("en"),
+		Stopwords: []string{"Germany", "France", "Italy", "United States"},
+	}
+
+	expectedResult := map[string]api.StopwordsSetSchema{}
+	for i := 0; i < total; i++ {
+		expectedResult[stopwordsSetIDs[i]] = api.StopwordsSetSchema{
+			Id:        stopwordsSetIDs[i],
+			Locale:    upsertData.Locale,
+			Stopwords: []string{"states", "united", "france", "germany", "italy"},
+		}
+	}
+
+	for i := 0; i < total; i++ {
+		_, err := typesenseClient.Stopwords().Upsert(context.Background(), stopwordsSetIDs[i], upsertData)
+		require.NoError(t, err)
+	}
+
+	result, err := typesenseClient.Stopwords().Retrieve(context.Background())
+
+	require.NoError(t, err)
+	require.True(t, len(result) >= total, "number of stopwordsSets is invalid")
+
+	resultMap := map[string]api.StopwordsSetSchema{}
+	for _, stopwordsSet := range result {
+		resultMap[stopwordsSet.Id] = stopwordsSet
+	}
+
+	for k, v := range expectedResult {
+		assert.Equal(t, v, resultMap[k])
+	}
+}

--- a/typesense/test/stopwords_test.go
+++ b/typesense/test/stopwords_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/typesense/typesense-go/typesense/api"
-	"github.com/typesense/typesense-go/typesense/api/pointer"
+	"github.com/typesense/typesense-go/v2/typesense/api"
+	"github.com/typesense/typesense-go/v2/typesense/api/pointer"
 )
 
 func TestStopwordsUpsert(t *testing.T) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Also fix some bugs in [multi-search integration test](https://github.com/typesense/typesense-go/commit/5ec3657dcd19c1a13e387015efd86f3c20ac9724)


### Create or update a stopwords set
```go
	stopwords := &api.StopwordsSetUpsertSchema{
		Locale:    pointer.String("en"),
		Stopwords: []string{"Germany", "France", "Italy", "United States"},
	}
	client.Stopwords().Upsert(context.Background(), "stopword_set1", stopwords)
```

### Retrieve a stopwords set

```go
client.Stopword("stopword_set1").Retrieve(context.Background())
```

### List all stopwords sets

```go
client.Stopwords().Retrieve(context.Background())
```

### Delete a stopwords set

```go
client.Stopword("stopword_set1").Delete(context.Background())
```
### Cluster Metrics

```go
client.Metrics().Retrieve(context.Background())
```

### API Stats

```go
client.Stats().Retrieve(context.Background())
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
