### PR TITLE
fix: multi-node returns early when request is aborted

### DIFF
--- a/typesense/api_call.go
+++ b/typesense/api_call.go
@@ -1,6 +1,8 @@
 package typesense
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"time"
@@ -72,6 +74,11 @@ func (a *APICall) Do(req *http.Request) (*http.Response, error) {
 		replaceRequestHostname(req, node.url)
 
 		response, err := a.client.Do(req)
+
+		// return early if request is aborted
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 
 		// If connection timeouts or status 5xx, retry with the next node
 		if err != nil || response.StatusCode >= 500 {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Cancel the loop early to avoid unnecessary iterations and nodes being falsely marked as unhealthy.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
