### PR TITLE
fixes geo-distance-meters type error

### DIFF
--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -1241,7 +1241,7 @@ type SearchResultHit struct {
 	Document *map[string]interface{} `json:"document,omitempty"`
 
 	// GeoDistanceMeters Can be any key-value pair
-	GeoDistanceMeters *map[string]float64 `json:"geo_distance_meters,omitempty"`
+	GeoDistanceMeters *map[string]float32 `json:"geo_distance_meters,omitempty"`
 
 	// Highlight Highlighted version of the matching document
 	Highlight *map[string]interface{} `json:"highlight,omitempty"`

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -1241,7 +1241,7 @@ type SearchResultHit struct {
 	Document *map[string]interface{} `json:"document,omitempty"`
 
 	// GeoDistanceMeters Can be any key-value pair
-	GeoDistanceMeters *map[string]int `json:"geo_distance_meters,omitempty"`
+	GeoDistanceMeters *map[string]float64 `json:"geo_distance_meters,omitempty"`
 
 	// Highlight Highlighted version of the matching document
 	Highlight *map[string]interface{} `json:"highlight,omitempty"`


### PR DESCRIPTION
fixes issue where typesense returns geo-distance-meters as a float, causing an unmarshalling error when decoding to an int;

## Change Summary
Changed `SearchResultHit.GeoDistanceMeters` from type `*map[string]int` to `*map[string]float32`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
