### PR TITLE
Update client for v28 changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.22'
 
           
       - name: Install dependencies

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,18 @@ jobs:
         with:
           go-version: stable
 
+          
+      - name: Install dependencies
+        run: |
+          go mod download
+          go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+          
+      - name: Generate API code
+        run: go generate ./...
+          
+      - name: Clean module cache
+        run: go clean -modcache
+        
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -534,10 +534,32 @@ components:
           description: |
             Values are stemmed before indexing in-memory. Default: false.
           type: boolean
+        stem_dictionary:
+          description: Name of the stemming dictionary to use for this field
+          example: irregular-plurals
+          type: string
         store:
           description: |
             When set to false, the field value will not be stored on disk. Default: true.
           type: boolean
+        symbols_to_index:
+          default: []
+          description: |
+            List of symbols or special characters to be indexed.
+          items:
+            maxLength: 1
+            minLength: 1
+            type: string
+          type: array
+        token_separators:
+          default: []
+          description: |
+            List of symbols or special characters to be used for splitting the text into individual words in addition to space and new-line characters.
+          items:
+            maxLength: 1
+            minLength: 1
+            type: string
+          type: array
         type:
           example: string
           type: string
@@ -571,6 +593,11 @@ components:
               description: |
                 The collection to search in.
               type: string
+            rerank_hybrid_matches:
+              default: false
+              description: |
+                When true, computes both text match and vector distance scores for all matches in hybrid search. Documents found only through keyword search will get a vector distance score, and documents found only through vector search will get a text match score.
+              type: boolean
             x-typesense-api-key:
               description: A separate search API key for each search within a multi_search request
               type: string
@@ -848,6 +875,9 @@ components:
           items:
             $ref: '#/components/schemas/MultiSearchCollectionParameters'
           type: array
+        union:
+          description: When true, merges the search results from each search query into a single ordered set of hits.
+          type: boolean
       required:
         - searches
       type: object
@@ -884,6 +914,18 @@ components:
           x-go-type: '[]*PresetSchema'
       required:
         - presets
+      type: object
+    SchemaChangeStatus:
+      properties:
+        altered_docs:
+          description: Number of documents that have been altered
+          type: integer
+        collection:
+          description: Name of the collection being modified
+          type: string
+        validated_docs:
+          description: Number of documents that have been validated
+          type: integer
       type: object
     ScopedKeyParameters:
       properties:
@@ -1207,6 +1249,9 @@ components:
         max_facet_values:
           description: Maximum number of facet values to be returned.
           type: integer
+        max_filter_by_candidates:
+          description: Controls the number of similar words that Typesense considers during fuzzy search on filter_by values. Useful for controlling prefix matches like company_name:Acm*.
+          type: integer
         min_len_1typo:
           description: |
             Minimum word length for 1-typo correction to be applied. The value of num_typos is still treated as the maximum allowed typos.
@@ -1508,6 +1553,33 @@ components:
         snapshot_path:
           type: string
       type: object
+    StemmingDictionary:
+      properties:
+        id:
+          description: Unique identifier for the dictionary
+          example: irregular-plurals
+          type: string
+        words:
+          description: List of word mappings in the dictionary
+          items:
+            properties:
+              root:
+                description: The root form of the word
+                example: person
+                type: string
+              word:
+                description: The word form to be stemmed
+                example: people
+                type: string
+            required:
+              - word
+              - root
+            type: object
+          type: array
+      required:
+        - id
+        - words
+      type: object
     StopwordsSetRetrieveSchema:
       example: |
         {"stopwords": {"id": "countries", "stopwords": ["Germany", "France", "Italy"], "locale": "en"}}
@@ -1583,7 +1655,7 @@ externalDocs:
 info:
   description: An open source search engine for building delightful search experiences.
   title: Typesense API
-  version: "27.0"
+  version: "28.0"
 openapi: 3.0.3
 paths:
   /aliases:
@@ -2005,6 +2077,10 @@ paths:
             type: string
         - in: query
           name: ignore_not_found
+          schema:
+            type: boolean
+        - in: query
+          name: truncate
           schema:
             type: boolean
       responses:
@@ -2502,6 +2578,10 @@ paths:
             type: integer
         - in: query
           name: max_facet_values
+          schema:
+            type: integer
+        - in: query
+          name: max_filter_by_candidates
           schema:
             type: integer
         - in: query
@@ -3303,6 +3383,10 @@ paths:
           schema:
             type: integer
         - in: query
+          name: max_filter_by_candidates
+          schema:
+            type: integer
+        - in: query
           name: min_len_1typo
           schema:
             type: integer
@@ -3447,6 +3531,22 @@ paths:
       summary: send multiple search requests in a single HTTP request
       tags:
         - documents
+  /operations/schema_changes:
+    get:
+      description: Returns the status of any ongoing schema change operations. If no schema changes are in progress, returns an empty response.
+      operationId: getSchemaChanges
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/SchemaChangeStatus'
+                type: array
+          description: List of schema changes in progress
+      summary: Get the status of in-progress schema change operations
+      tags:
+        - operations
   /operations/snapshot:
     post:
       description: Creates a point-in-time snapshot of a Typesense node's state and data in the specified directory. You can then backup the snapshot directory that gets created and later restore it as a data directory, as needed.
@@ -3599,6 +3699,96 @@ paths:
       summary: Get stats about API endpoints.
       tags:
         - operations
+  /stemming/dictionaries:
+    get:
+      description: Retrieve a list of all available stemming dictionaries.
+      operationId: listStemmingDictionaries
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  dictionaries:
+                    example:
+                      - irregular-plurals
+                      - company-terms
+                    items:
+                      type: string
+                    type: array
+                type: object
+          description: List of all dictionaries
+      summary: List all stemming dictionaries
+      tags:
+        - stemming
+  /stemming/dictionaries/{dictionaryId}:
+    get:
+      description: Fetch details of a specific stemming dictionary.
+      operationId: getStemmingDictionary
+      parameters:
+        - description: The ID of the dictionary to retrieve
+          example: irregular-plurals
+          in: path
+          name: dictionaryId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StemmingDictionary'
+          description: Stemming dictionary details
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: Dictionary not found
+      summary: Retrieve a stemming dictionary
+      tags:
+        - stemming
+  /stemming/dictionaries/import:
+    post:
+      description: Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+      operationId: importStemmingDictionary
+      parameters:
+        - description: The ID to assign to the dictionary
+          example: irregular-plurals
+          in: query
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example: |
+                {"word": "people", "root": "person"}
+                {"word": "children", "root": "child"}
+              type: string
+        description: The JSONL file containing word mappings
+        required: true
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                example: |
+                  {"word": "people", "root": "person"} {"word": "children", "root": "child"}
+                type: string
+          description: Dictionary successfully imported
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: Bad request, see error message for details
+      summary: Import a stemming dictionary
+      tags:
+        - stemming
   /stopwords:
     get:
       description: Retrieve the details of all stopwords sets
@@ -3730,7 +3920,7 @@ tags:
   - description: Typesense can aggregate search queries for both analytics purposes and for query suggestions.
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/analytics-query-suggestions.html
+      url: https://typesense.org/docs/28.0/api/analytics-query-suggestions.html
     name: analytics
   - description: Manage API Keys with fine-grain access control
     externalDocs:
@@ -3742,25 +3932,30 @@ tags:
   - description: Manage Typesense cluster
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/cluster-operations.html
+      url: https://typesense.org/docs/28.0/api/cluster-operations.html
     name: operations
   - description: Manage stopwords sets
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/stopwords.html
+      url: https://typesense.org/docs/28.0/api/stopwords.html
     name: stopwords
   - description: Store and reference search parameters
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/search.html#presets
+      url: https://typesense.org/docs/28.0/api/search.html#presets
     name: presets
   - description: Conversational Search (RAG)
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/conversational-search-rag.html
+      url: https://typesense.org/docs/28.0/api/conversational-search-rag.html
     name: conversations
   - description: Manage synonyms
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/synonyms.html
+      url: https://typesense.org/docs/28.0/api/synonyms.html
     name: synonyms
+  - description: Manage stemming dictionaries
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/28.0/api/stemming.html
+    name: stemming

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Typesense API
   description: "An open source search engine for building delightful search experiences."
-  version: '27.0'
+  version: '28.0'
 externalDocs:
   description: Find out more about Typsesense
   url: https://typesense.org
@@ -28,7 +28,7 @@ tags:
     description: Typesense can aggregate search queries for both analytics purposes and for query suggestions.
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/analytics-query-suggestions.html
+      url: https://typesense.org/docs/28.0/api/analytics-query-suggestions.html
   - name: keys
     description: Manage API Keys with fine-grain access control
     externalDocs:
@@ -40,27 +40,32 @@ tags:
     description: Manage Typesense cluster
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/cluster-operations.html
+      url: https://typesense.org/docs/28.0/api/cluster-operations.html
   - name: stopwords
     description: Manage stopwords sets
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/stopwords.html
+      url: https://typesense.org/docs/28.0/api/stopwords.html
   - name: presets
     description: Store and reference search parameters
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/26.0/api/search.html#presets
+      url: https://typesense.org/docs/28.0/api/search.html#presets
   - name: conversations
     description: Conversational Search (RAG)
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/conversational-search-rag.html
+      url: https://typesense.org/docs/28.0/api/conversational-search-rag.html
   - name: synonyms
     description: Manage synonyms
     externalDocs:
       description: Find out more
-      url: https://typesense.org/docs/27.0/api/synonyms.html
+      url: https://typesense.org/docs/28.0/api/synonyms.html
+  - name: stemming
+    description: Manage stemming dictionaries
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/28.0/api/stemming.html
 paths:
   /collections:
     get:
@@ -356,6 +361,9 @@ paths:
                   of other operations running on the server.
                 type: integer
               ignore_not_found:
+                type: boolean
+              truncate:
+                description: When true, removes all documents from the collection while preserving the collection and its schema.
                 type: boolean
       responses:
         '200':
@@ -1263,6 +1271,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthStatus"
+  /operations/schema_changes:
+    get:
+      tags:
+        - operations
+      summary: Get the status of in-progress schema change operations
+      description: Returns the status of any ongoing schema change operations. If no schema changes are in progress, returns an empty response.
+      operationId: getSchemaChanges
+      responses:
+        '200':
+          description: List of schema changes in progress
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SchemaChangeStatus"
   /operations/snapshot:
     post:
       tags:
@@ -1742,6 +1766,97 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
+  /stemming/dictionaries:
+    get:
+      tags:
+        - stemming
+      summary: List all stemming dictionaries
+      description: Retrieve a list of all available stemming dictionaries.
+      operationId: listStemmingDictionaries
+      responses:
+        '200':
+          description: List of all dictionaries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dictionaries:
+                    type: array
+                    items:
+                      type: string
+                    example: ["irregular-plurals", "company-terms"]
+
+  /stemming/dictionaries/{dictionaryId}:
+    get:
+      tags:
+        - stemming
+      summary: Retrieve a stemming dictionary
+      description: Fetch details of a specific stemming dictionary.
+      operationId: getStemmingDictionary
+      parameters:
+        - name: dictionaryId
+          in: path
+          description: The ID of the dictionary to retrieve
+          required: true
+          schema:
+            type: string
+          example: irregular-plurals
+      responses:
+        '200':
+          description: Stemming dictionary details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StemmingDictionary"
+        '404':
+          description: Dictionary not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+
+  /stemming/dictionaries/import:
+    post:
+      tags:
+        - stemming
+      summary: Import a stemming dictionary
+      description: Upload a JSONL file containing word mappings to create or update a stemming dictionary.
+      operationId: importStemmingDictionary
+      parameters:
+        - name: id
+          in: query
+          description: The ID to assign to the dictionary
+          required: true
+          schema:
+            type: string
+          example: irregular-plurals
+      requestBody:
+        description: The JSONL file containing word mappings
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              example: |
+                {"word": "people", "root": "person"}
+                {"word": "children", "root": "child"}
+      responses:
+        '200':
+          description: Dictionary successfully imported
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                example: >
+                  {"word": "people", "root": "person"}
+                  {"word": "children", "root": "child"}
+        '400':
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
 components:
   schemas:
     CollectionSchema:
@@ -1906,6 +2021,33 @@ components:
           type: boolean
           description: >
             Values are stemmed before indexing in-memory. Default: false.
+        stem_dictionary:
+          type: string
+          description: Name of the stemming dictionary to use for this field
+          example: irregular-plurals
+        token_separators:
+          type: array
+          description: >
+            List of symbols or special characters to be used for
+            splitting the text into individual words in addition to space and new-line characters.
+          items:
+            type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
+          default: []
+        symbols_to_index:
+          type: array
+          description: >
+            List of symbols or special characters to be indexed.
+          items:
+            type: string # characters only
+            # Could `enum` be used instead, given it's symbols/special *characters*, e.g.:
+            # enum: ["@", "!", ".", "/", ","]
+            minLength: 1
+            maxLength: 1
+          default: []
         embed:
           type: object
           required:
@@ -2353,6 +2495,18 @@ components:
       properties:
         ok:
           type: boolean
+    SchemaChangeStatus:
+      type: object
+      properties:
+        collection:
+          type: string
+          description: Name of the collection being modified
+        validated_docs:
+          type: integer
+          description: Number of documents that have been validated
+        altered_docs:
+          type: integer
+          description: Number of documents that have been altered
     SuccessStatus:
       type: object
       required:
@@ -2526,6 +2680,12 @@ components:
             multiple conditions with &&.
           type: string
           example: "num_employees:>100 && country: [USA, UK]"
+
+        max_filter_by_candidates:
+          description:
+            Controls the number of similar words that Typesense considers during fuzzy search
+            on filter_by values. Useful for controlling prefix matches like company_name:Acm*.
+          type: integer
 
         sort_by:
           description:
@@ -3218,6 +3378,9 @@ components:
       required:
         - searches
       properties:
+        union:
+          type: boolean
+          description: When true, merges the search results from each search query into a single ordered set of hits.
         searches:
           type: array
           items:
@@ -3234,6 +3397,13 @@ components:
             x-typesense-api-key:
               type: string
               description: A separate search API key for each search within a multi_search request
+            rerank_hybrid_matches:
+              type: boolean
+              description: >
+                When true, computes both text match and vector distance scores for all matches in hybrid search.
+                Documents found only through keyword search will get a vector distance score, and
+                documents found only through vector search will get a text match score.
+              default: false
     FacetCounts:
       type: object
       properties:
@@ -3584,6 +3754,33 @@ components:
             id:
               type: string
               description: An explicit id for the model, otherwise the API will return a response with an auto-generated conversation model id.
+    StemmingDictionary:
+      type: object
+      required:
+        - id
+        - words
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the dictionary
+          example: irregular-plurals
+        words:
+          type: array
+          description: List of word mappings in the dictionary
+          items:
+            type: object
+            required:
+              - word
+              - root
+            properties:
+              word:
+                type: string
+                description: The word form to be stemmed
+                example: people
+              root:
+                type: string
+                description: The root form of the word
+                example: person
   securitySchemes:
     api_key_header:
       type: apiKey

--- a/typesense/api/types.go
+++ b/typesense/api/types.go
@@ -5,3 +5,8 @@ type ImportDocumentResponse struct {
 	Error    string `json:"error"`
 	Document string `json:"document"`
 }
+
+type StemmingDictionaryWord struct {
+    Root string `json:"root"`
+    Word string `json:"word"`
+}

--- a/typesense/api/types.go
+++ b/typesense/api/types.go
@@ -7,6 +7,6 @@ type ImportDocumentResponse struct {
 }
 
 type StemmingDictionaryWord struct {
-    Root string `json:"root"`
-    Word string `json:"word"`
+	Root string `json:"root"`
+	Word string `json:"word"`
 }

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -404,9 +404,18 @@ type Field struct {
 	// Stem Values are stemmed before indexing in-memory. Default: false.
 	Stem *bool `json:"stem,omitempty"`
 
+	// StemDictionary Name of the stemming dictionary to use for this field
+	StemDictionary *string `json:"stem_dictionary,omitempty"`
+
 	// Store When set to false, the field value will not be stored on disk. Default: true.
-	Store *bool  `json:"store,omitempty"`
-	Type  string `json:"type"`
+	Store *bool `json:"store,omitempty"`
+
+	// SymbolsToIndex List of symbols or special characters to be indexed.
+	SymbolsToIndex *[]string `json:"symbols_to_index,omitempty"`
+
+	// TokenSeparators List of symbols or special characters to be used for splitting the text into individual words in addition to space and new-line characters.
+	TokenSeparators *[]string `json:"token_separators,omitempty"`
+	Type            string    `json:"type"`
 
 	// VecDist The distance metric to be used for vector search. Default: `cosine`. You can also use `ip` for inner product.
 	VecDist *string `json:"vec_dist,omitempty"`
@@ -583,6 +592,9 @@ type MultiSearchCollectionParameters struct {
 
 	// RemoteEmbeddingTimeoutMs Timeout (in milliseconds) for fetching remote embeddings.
 	RemoteEmbeddingTimeoutMs *int `json:"remote_embedding_timeout_ms,omitempty"`
+
+	// RerankHybridMatches When true, computes both text match and vector distance scores for all matches in hybrid search. Documents found only through keyword search will get a vector distance score, and documents found only through vector search will get a text match score.
+	RerankHybridMatches *bool `json:"rerank_hybrid_matches,omitempty"`
 
 	// SearchCutoffMs Typesense will attempt to return results early if the cutoff time has elapsed. This is not a strict guarantee and facet computation is not bound by this parameter.
 	SearchCutoffMs *int `json:"search_cutoff_ms,omitempty"`
@@ -864,6 +876,9 @@ type MultiSearchResultItem struct {
 // MultiSearchSearchesParameter defines model for MultiSearchSearchesParameter.
 type MultiSearchSearchesParameter struct {
 	Searches []MultiSearchCollectionParameters `json:"searches"`
+
+	// Union When true, merges the search results from each search query into a single ordered set of hits.
+	Union *bool `json:"union,omitempty"`
 }
 
 // PresetDeleteSchema defines model for PresetDeleteSchema.
@@ -895,6 +910,18 @@ type PresetUpsertSchema_Value struct {
 // PresetsRetrieveSchema defines model for PresetsRetrieveSchema.
 type PresetsRetrieveSchema struct {
 	Presets []*PresetSchema `json:"presets"`
+}
+
+// SchemaChangeStatus defines model for SchemaChangeStatus.
+type SchemaChangeStatus struct {
+	// AlteredDocs Number of documents that have been altered
+	AlteredDocs *int `json:"altered_docs,omitempty"`
+
+	// Collection Name of the collection being modified
+	Collection *string `json:"collection,omitempty"`
+
+	// ValidatedDocs Number of documents that have been validated
+	ValidatedDocs *int `json:"validated_docs,omitempty"`
 }
 
 // SearchGroupedHit defines model for SearchGroupedHit.
@@ -1154,6 +1181,9 @@ type SearchParameters struct {
 	// MaxFacetValues Maximum number of facet values to be returned.
 	MaxFacetValues *int `json:"max_facet_values,omitempty"`
 
+	// MaxFilterByCandidates Controls the number of similar words that Typesense considers during fuzzy search on filter_by values. Useful for controlling prefix matches like company_name:Acm*.
+	MaxFilterByCandidates *int `json:"max_filter_by_candidates,omitempty"`
+
 	// MinLen1typo Minimum word length for 1-typo correction to be applied. The value of num_typos is still treated as the maximum allowed typos.
 	MinLen1typo *int `json:"min_len_1typo,omitempty"`
 
@@ -1363,6 +1393,21 @@ type SearchSynonymsResponse struct {
 	Synonyms []*SearchSynonym `json:"synonyms"`
 }
 
+// StemmingDictionary defines model for StemmingDictionary.
+type StemmingDictionary struct {
+	// Id Unique identifier for the dictionary
+	Id string `json:"id"`
+
+	// Words List of word mappings in the dictionary
+	Words []struct {
+		// Root The root form of the word
+		Root string `json:"root"`
+
+		// Word The word form to be stemmed
+		Word string `json:"word"`
+	} `json:"words"`
+}
+
 // StopwordsSetRetrieveSchema defines model for StopwordsSetRetrieveSchema.
 type StopwordsSetRetrieveSchema struct {
 	Stopwords StopwordsSetSchema `json:"stopwords"`
@@ -1401,6 +1446,7 @@ type DeleteDocumentsParams struct {
 	BatchSize      *int    `form:"batch_size,omitempty" json:"batch_size,omitempty"`
 	FilterBy       *string `form:"filter_by,omitempty" json:"filter_by,omitempty"`
 	IgnoreNotFound *bool   `form:"ignore_not_found,omitempty" json:"ignore_not_found,omitempty"`
+	Truncate       *bool   `form:"truncate,omitempty" json:"truncate,omitempty"`
 }
 
 // UpdateDocumentsJSONBody defines parameters for UpdateDocuments.
@@ -1477,6 +1523,7 @@ type SearchCollectionParams struct {
 	MaxExtraPrefix                     *int            `form:"max_extra_prefix,omitempty" json:"max_extra_prefix,omitempty"`
 	MaxExtraSuffix                     *int            `form:"max_extra_suffix,omitempty" json:"max_extra_suffix,omitempty"`
 	MaxFacetValues                     *int            `form:"max_facet_values,omitempty" json:"max_facet_values,omitempty"`
+	MaxFilterByCandidates              *int            `form:"max_filter_by_candidates,omitempty" json:"max_filter_by_candidates,omitempty"`
 	MinLen1typo                        *int            `form:"min_len_1typo,omitempty" json:"min_len_1typo,omitempty"`
 	MinLen2typo                        *int            `form:"min_len_2typo,omitempty" json:"min_len_2typo,omitempty"`
 	NumTypos                           *string         `form:"num_typos,omitempty" json:"num_typos,omitempty"`
@@ -1556,6 +1603,7 @@ type MultiSearchParams struct {
 	MaxExtraPrefix                     *int            `form:"max_extra_prefix,omitempty" json:"max_extra_prefix,omitempty"`
 	MaxExtraSuffix                     *int            `form:"max_extra_suffix,omitempty" json:"max_extra_suffix,omitempty"`
 	MaxFacetValues                     *int            `form:"max_facet_values,omitempty" json:"max_facet_values,omitempty"`
+	MaxFilterByCandidates              *int            `form:"max_filter_by_candidates,omitempty" json:"max_filter_by_candidates,omitempty"`
 	MinLen1typo                        *int            `form:"min_len_1typo,omitempty" json:"min_len_1typo,omitempty"`
 	MinLen2typo                        *int            `form:"min_len_2typo,omitempty" json:"min_len_2typo,omitempty"`
 	NumTypos                           *string         `form:"num_typos,omitempty" json:"num_typos,omitempty"`
@@ -1593,6 +1641,15 @@ type MultiSearchParams struct {
 type TakeSnapshotParams struct {
 	// SnapshotPath The directory on the server where the snapshot should be saved.
 	SnapshotPath string `form:"snapshot_path" json:"snapshot_path"`
+}
+
+// ImportStemmingDictionaryJSONBody defines parameters for ImportStemmingDictionary.
+type ImportStemmingDictionaryJSONBody = string
+
+// ImportStemmingDictionaryParams defines parameters for ImportStemmingDictionary.
+type ImportStemmingDictionaryParams struct {
+	// Id The ID to assign to the dictionary
+	Id string `form:"id" json:"id"`
 }
 
 // UpsertAliasJSONRequestBody defines body for UpsertAlias for application/json ContentType.
@@ -1642,6 +1699,9 @@ type MultiSearchJSONRequestBody = MultiSearchSearchesParameter
 
 // UpsertPresetJSONRequestBody defines body for UpsertPreset for application/json ContentType.
 type UpsertPresetJSONRequestBody = PresetUpsertSchema
+
+// ImportStemmingDictionaryJSONRequestBody defines body for ImportStemmingDictionary for application/json ContentType.
+type ImportStemmingDictionaryJSONRequestBody = ImportStemmingDictionaryJSONBody
 
 // UpsertStopwordsSetJSONRequestBody defines body for UpsertStopwordsSet for application/json ContentType.
 type UpsertStopwordsSetJSONRequestBody = StopwordsSetUpsertSchema

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -48,6 +48,10 @@ func (c *Client) Analytics() AnalyticsInterface {
 	return &analytics{apiClient: c.apiClient}
 }
 
+func (c *Client) Stemming() StemmingInterface {
+	return &stemming{apiClient: c.apiClient}
+}
+
 func (c *Client) Conversations() ConversationsInterface {
 	return &conversations{apiClient: c.apiClient}
 }

--- a/typesense/mocks/mock_client.go
+++ b/typesense/mocks/mock_client.go
@@ -1243,6 +1243,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) GetKeysWithResponse(ctx any, reqEd
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeysWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).GetKeysWithResponse), varargs...)
 }
 
+// GetSchemaChanges mocks base method.
+func (m *MockAPIClientInterface) GetSchemaChanges(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSchemaChanges", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchemaChanges indicates an expected call of GetSchemaChanges.
+func (mr *MockAPIClientInterfaceMockRecorder) GetSchemaChanges(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchemaChanges", reflect.TypeOf((*MockAPIClientInterface)(nil).GetSchemaChanges), varargs...)
+}
+
+// GetSchemaChangesWithResponse mocks base method.
+func (m *MockAPIClientInterface) GetSchemaChangesWithResponse(ctx context.Context, reqEditors ...api.RequestEditorFn) (*api.GetSchemaChangesResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSchemaChangesWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.GetSchemaChangesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchemaChangesWithResponse indicates an expected call of GetSchemaChangesWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) GetSchemaChangesWithResponse(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchemaChangesWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).GetSchemaChangesWithResponse), varargs...)
+}
+
 // GetSearchOverride mocks base method.
 func (m *MockAPIClientInterface) GetSearchOverride(ctx context.Context, collectionName, overrideId string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1403,6 +1443,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) GetSearchSynonymsWithResponse(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchSynonymsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).GetSearchSynonymsWithResponse), varargs...)
 }
 
+// GetStemmingDictionary mocks base method.
+func (m *MockAPIClientInterface) GetStemmingDictionary(ctx context.Context, dictionaryId string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, dictionaryId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetStemmingDictionary", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStemmingDictionary indicates an expected call of GetStemmingDictionary.
+func (mr *MockAPIClientInterfaceMockRecorder) GetStemmingDictionary(ctx, dictionaryId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, dictionaryId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStemmingDictionary", reflect.TypeOf((*MockAPIClientInterface)(nil).GetStemmingDictionary), varargs...)
+}
+
+// GetStemmingDictionaryWithResponse mocks base method.
+func (m *MockAPIClientInterface) GetStemmingDictionaryWithResponse(ctx context.Context, dictionaryId string, reqEditors ...api.RequestEditorFn) (*api.GetStemmingDictionaryResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, dictionaryId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetStemmingDictionaryWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.GetStemmingDictionaryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStemmingDictionaryWithResponse indicates an expected call of GetStemmingDictionaryWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) GetStemmingDictionaryWithResponse(ctx, dictionaryId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, dictionaryId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStemmingDictionaryWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).GetStemmingDictionaryWithResponse), varargs...)
+}
+
 // Health mocks base method.
 func (m *MockAPIClientInterface) Health(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1483,6 +1563,86 @@ func (mr *MockAPIClientInterfaceMockRecorder) ImportDocumentsWithBodyWithRespons
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportDocumentsWithBodyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).ImportDocumentsWithBodyWithResponse), varargs...)
 }
 
+// ImportStemmingDictionary mocks base method.
+func (m *MockAPIClientInterface) ImportStemmingDictionary(ctx context.Context, params *api.ImportStemmingDictionaryParams, body api.ImportStemmingDictionaryJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportStemmingDictionary", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportStemmingDictionary indicates an expected call of ImportStemmingDictionary.
+func (mr *MockAPIClientInterfaceMockRecorder) ImportStemmingDictionary(ctx, params, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportStemmingDictionary", reflect.TypeOf((*MockAPIClientInterface)(nil).ImportStemmingDictionary), varargs...)
+}
+
+// ImportStemmingDictionaryWithBody mocks base method.
+func (m *MockAPIClientInterface) ImportStemmingDictionaryWithBody(ctx context.Context, params *api.ImportStemmingDictionaryParams, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportStemmingDictionaryWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportStemmingDictionaryWithBody indicates an expected call of ImportStemmingDictionaryWithBody.
+func (mr *MockAPIClientInterfaceMockRecorder) ImportStemmingDictionaryWithBody(ctx, params, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportStemmingDictionaryWithBody", reflect.TypeOf((*MockAPIClientInterface)(nil).ImportStemmingDictionaryWithBody), varargs...)
+}
+
+// ImportStemmingDictionaryWithBodyWithResponse mocks base method.
+func (m *MockAPIClientInterface) ImportStemmingDictionaryWithBodyWithResponse(ctx context.Context, params *api.ImportStemmingDictionaryParams, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*api.ImportStemmingDictionaryResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportStemmingDictionaryWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.ImportStemmingDictionaryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportStemmingDictionaryWithBodyWithResponse indicates an expected call of ImportStemmingDictionaryWithBodyWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) ImportStemmingDictionaryWithBodyWithResponse(ctx, params, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportStemmingDictionaryWithBodyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).ImportStemmingDictionaryWithBodyWithResponse), varargs...)
+}
+
+// ImportStemmingDictionaryWithResponse mocks base method.
+func (m *MockAPIClientInterface) ImportStemmingDictionaryWithResponse(ctx context.Context, params *api.ImportStemmingDictionaryParams, body api.ImportStemmingDictionaryJSONRequestBody, reqEditors ...api.RequestEditorFn) (*api.ImportStemmingDictionaryResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ImportStemmingDictionaryWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.ImportStemmingDictionaryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportStemmingDictionaryWithResponse indicates an expected call of ImportStemmingDictionaryWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) ImportStemmingDictionaryWithResponse(ctx, params, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportStemmingDictionaryWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).ImportStemmingDictionaryWithResponse), varargs...)
+}
+
 // IndexDocument mocks base method.
 func (m *MockAPIClientInterface) IndexDocument(ctx context.Context, collectionName string, params *api.IndexDocumentParams, body api.IndexDocumentJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -1561,6 +1721,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) IndexDocumentWithResponse(ctx, col
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, collectionName, params, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexDocumentWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).IndexDocumentWithResponse), varargs...)
+}
+
+// ListStemmingDictionaries mocks base method.
+func (m *MockAPIClientInterface) ListStemmingDictionaries(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListStemmingDictionaries", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStemmingDictionaries indicates an expected call of ListStemmingDictionaries.
+func (mr *MockAPIClientInterfaceMockRecorder) ListStemmingDictionaries(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStemmingDictionaries", reflect.TypeOf((*MockAPIClientInterface)(nil).ListStemmingDictionaries), varargs...)
+}
+
+// ListStemmingDictionariesWithResponse mocks base method.
+func (m *MockAPIClientInterface) ListStemmingDictionariesWithResponse(ctx context.Context, reqEditors ...api.RequestEditorFn) (*api.ListStemmingDictionariesResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListStemmingDictionariesWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.ListStemmingDictionariesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStemmingDictionariesWithResponse indicates an expected call of ListStemmingDictionariesWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) ListStemmingDictionariesWithResponse(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStemmingDictionariesWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).ListStemmingDictionariesWithResponse), varargs...)
 }
 
 // MultiSearch mocks base method.

--- a/typesense/stemming.go
+++ b/typesense/stemming.go
@@ -1,18 +1,18 @@
 package typesense
 
 type StemmingInterface interface {
-    Dictionaries() StemmingDictionariesInterface
-    Dictionary(dictionaryId string) StemmingDictionaryInterface
+	Dictionaries() StemmingDictionariesInterface
+	Dictionary(dictionaryId string) StemmingDictionaryInterface
 }
 
 type stemming struct {
-    apiClient APIClientInterface
+	apiClient APIClientInterface
 }
 
 func (s *stemming) Dictionaries() StemmingDictionariesInterface {
-    return &stemmingDictionaries{apiClient: s.apiClient}
+	return &stemmingDictionaries{apiClient: s.apiClient}
 }
 
 func (s *stemming) Dictionary(dictionaryId string) StemmingDictionaryInterface {
-    return &stemmingDictionary{apiClient: s.apiClient, dictionaryId: dictionaryId}
+	return &stemmingDictionary{apiClient: s.apiClient, dictionaryId: dictionaryId}
 }

--- a/typesense/stemming.go
+++ b/typesense/stemming.go
@@ -1,0 +1,18 @@
+package typesense
+
+type StemmingInterface interface {
+    Dictionaries() StemmingDictionariesInterface
+    Dictionary(dictionaryId string) StemmingDictionaryInterface
+}
+
+type stemming struct {
+    apiClient APIClientInterface
+}
+
+func (s *stemming) Dictionaries() StemmingDictionariesInterface {
+    return &stemmingDictionaries{apiClient: s.apiClient}
+}
+
+func (s *stemming) Dictionary(dictionaryId string) StemmingDictionaryInterface {
+    return &stemmingDictionary{apiClient: s.apiClient, dictionaryId: dictionaryId}
+}

--- a/typesense/stemming_dictionaries.go
+++ b/typesense/stemming_dictionaries.go
@@ -11,74 +11,74 @@ import (
 )
 
 type StemmingDictionariesInterface interface {
-    Upsert(ctx context.Context, dictionaryId string, wordRootCombinations []api.StemmingDictionaryWord) ([]*api.StemmingDictionaryWord, error)
-    UpsertJsonl(ctx context.Context, dictionaryId string, body io.Reader) (io.ReadCloser, error)
-    Retrieve(ctx context.Context) (*api.ListStemmingDictionariesResponse, error)
+	Upsert(ctx context.Context, dictionaryId string, wordRootCombinations []api.StemmingDictionaryWord) ([]*api.StemmingDictionaryWord, error)
+	UpsertJsonl(ctx context.Context, dictionaryId string, body io.Reader) (io.ReadCloser, error)
+	Retrieve(ctx context.Context) (*api.ListStemmingDictionariesResponse, error)
 }
 
 type stemmingDictionaries struct {
-    apiClient APIClientInterface
+	apiClient APIClientInterface
 }
 
 func (s *stemmingDictionaries) Upsert(ctx context.Context, dictionaryId string, wordRootCombinations []api.StemmingDictionaryWord) ([]*api.StemmingDictionaryWord, error) {
-    var buf bytes.Buffer
-    jsonEncoder := json.NewEncoder(&buf)
-    for _, combo := range wordRootCombinations {
-        if err := jsonEncoder.Encode(combo); err != nil {
-            return nil, err
-        }
-    }
+	var buf bytes.Buffer
+	jsonEncoder := json.NewEncoder(&buf)
+	for _, combo := range wordRootCombinations {
+		if err := jsonEncoder.Encode(combo); err != nil {
+			return nil, err
+		}
+	}
 
-    response, err := s.UpsertJsonl(ctx, dictionaryId, &buf)
-    if err != nil {
-        return nil, err
-    }
+	response, err := s.UpsertJsonl(ctx, dictionaryId, &buf)
+	if err != nil {
+		return nil, err
+	}
 
-    var result []*api.StemmingDictionaryWord
-    jsonDecoder := json.NewDecoder(response)
-    for jsonDecoder.More() {
-        var docResult *api.StemmingDictionaryWord
-        if err := jsonDecoder.Decode(&docResult); err != nil {
-            return result, err
-        }
-        result = append(result, docResult)
-    }
+	var result []*api.StemmingDictionaryWord
+	jsonDecoder := json.NewDecoder(response)
+	for jsonDecoder.More() {
+		var docResult *api.StemmingDictionaryWord
+		if err := jsonDecoder.Decode(&docResult); err != nil {
+			return result, err
+		}
+		result = append(result, docResult)
+	}
 
-    return result, nil
+	return result, nil
 }
 
 func (s *stemmingDictionaries) UpsertJsonl(ctx context.Context, dictionaryId string, body io.Reader) (io.ReadCloser, error) {
-    params := &api.ImportStemmingDictionaryParams{
-        Id: dictionaryId,
-    }
-    
-    response, err := s.apiClient.ImportStemmingDictionaryWithBody(ctx,
-        params, "application/octet-stream", body)
-    if err != nil {
-        return nil, err
-    }
-    if response.StatusCode != http.StatusOK {
-        defer response.Body.Close()
-        body, _ := io.ReadAll(response.Body)
-        return nil, &HTTPError{Status: response.StatusCode, Body: body}
-    }
-    return response.Body, nil
+	params := &api.ImportStemmingDictionaryParams{
+		Id: dictionaryId,
+	}
+
+	response, err := s.apiClient.ImportStemmingDictionaryWithBody(ctx,
+		params, "application/octet-stream", body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		defer response.Body.Close()
+		body, _ := io.ReadAll(response.Body)
+		return nil, &HTTPError{Status: response.StatusCode, Body: body}
+	}
+	return response.Body, nil
 }
 
 func (s *stemmingDictionaries) Retrieve(ctx context.Context) (*api.ListStemmingDictionariesResponse, error) {
-    response, err := s.apiClient.ListStemmingDictionariesWithResponse(ctx)
-    if err != nil {
-        return nil, err
-    }
-    if response.JSON200 == nil {
-        emptySlice := make([]string, 0)
-        return &api.ListStemmingDictionariesResponse{
-            JSON200: &struct {
-                Dictionaries *[]string `json:"dictionaries,omitempty"`
-            }{
-                Dictionaries: &emptySlice,
-            },
-        }, nil
-    }
-    return response, nil
+	response, err := s.apiClient.ListStemmingDictionariesWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		emptySlice := make([]string, 0)
+		return &api.ListStemmingDictionariesResponse{
+			JSON200: &struct {
+				Dictionaries *[]string `json:"dictionaries,omitempty"`
+			}{
+				Dictionaries: &emptySlice,
+			},
+		}, nil
+	}
+	return response, nil
 }

--- a/typesense/stemming_dictionaries.go
+++ b/typesense/stemming_dictionaries.go
@@ -1,0 +1,84 @@
+package typesense
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/typesense/typesense-go/v3/typesense/api"
+)
+
+type StemmingDictionariesInterface interface {
+    Upsert(ctx context.Context, dictionaryId string, wordRootCombinations []api.StemmingDictionaryWord) ([]*api.StemmingDictionaryWord, error)
+    UpsertJsonl(ctx context.Context, dictionaryId string, body io.Reader) (io.ReadCloser, error)
+    Retrieve(ctx context.Context) (*api.ListStemmingDictionariesResponse, error)
+}
+
+type stemmingDictionaries struct {
+    apiClient APIClientInterface
+}
+
+func (s *stemmingDictionaries) Upsert(ctx context.Context, dictionaryId string, wordRootCombinations []api.StemmingDictionaryWord) ([]*api.StemmingDictionaryWord, error) {
+    var buf bytes.Buffer
+    jsonEncoder := json.NewEncoder(&buf)
+    for _, combo := range wordRootCombinations {
+        if err := jsonEncoder.Encode(combo); err != nil {
+            return nil, err
+        }
+    }
+
+    response, err := s.UpsertJsonl(ctx, dictionaryId, &buf)
+    if err != nil {
+        return nil, err
+    }
+
+    var result []*api.StemmingDictionaryWord
+    jsonDecoder := json.NewDecoder(response)
+    for jsonDecoder.More() {
+        var docResult *api.StemmingDictionaryWord
+        if err := jsonDecoder.Decode(&docResult); err != nil {
+            return result, err
+        }
+        result = append(result, docResult)
+    }
+
+    return result, nil
+}
+
+func (s *stemmingDictionaries) UpsertJsonl(ctx context.Context, dictionaryId string, body io.Reader) (io.ReadCloser, error) {
+    params := &api.ImportStemmingDictionaryParams{
+        Id: dictionaryId,
+    }
+    
+    response, err := s.apiClient.ImportStemmingDictionaryWithBody(ctx,
+        params, "application/octet-stream", body)
+    if err != nil {
+        return nil, err
+    }
+    if response.StatusCode != http.StatusOK {
+        defer response.Body.Close()
+        body, _ := io.ReadAll(response.Body)
+        return nil, &HTTPError{Status: response.StatusCode, Body: body}
+    }
+    return response.Body, nil
+}
+
+func (s *stemmingDictionaries) Retrieve(ctx context.Context) (*api.ListStemmingDictionariesResponse, error) {
+    response, err := s.apiClient.ListStemmingDictionariesWithResponse(ctx)
+    if err != nil {
+        return nil, err
+    }
+    if response.JSON200 == nil {
+        emptySlice := make([]string, 0)
+        return &api.ListStemmingDictionariesResponse{
+            JSON200: &struct {
+                Dictionaries *[]string `json:"dictionaries,omitempty"`
+            }{
+                Dictionaries: &emptySlice,
+            },
+        }, nil
+    }
+    return response, nil
+}

--- a/typesense/stemming_dictionary.go
+++ b/typesense/stemming_dictionary.go
@@ -1,0 +1,27 @@
+package typesense
+
+import (
+	"context"
+
+	"github.com/typesense/typesense-go/v3/typesense/api"
+)
+
+type StemmingDictionaryInterface interface {
+    Retrieve(ctx context.Context) (*api.StemmingDictionary, error)
+}
+
+type stemmingDictionary struct {
+    apiClient    APIClientInterface
+    dictionaryId string
+}
+
+func (s *stemmingDictionary) Retrieve(ctx context.Context) (*api.StemmingDictionary, error) {
+    response, err := s.apiClient.GetStemmingDictionaryWithResponse(ctx, s.dictionaryId)
+    if err != nil {
+        return nil, err
+    }
+    if response.JSON200 == nil {
+        return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+    }
+    return response.JSON200, nil
+}

--- a/typesense/stemming_dictionary.go
+++ b/typesense/stemming_dictionary.go
@@ -7,21 +7,21 @@ import (
 )
 
 type StemmingDictionaryInterface interface {
-    Retrieve(ctx context.Context) (*api.StemmingDictionary, error)
+	Retrieve(ctx context.Context) (*api.StemmingDictionary, error)
 }
 
 type stemmingDictionary struct {
-    apiClient    APIClientInterface
-    dictionaryId string
+	apiClient    APIClientInterface
+	dictionaryId string
 }
 
 func (s *stemmingDictionary) Retrieve(ctx context.Context) (*api.StemmingDictionary, error) {
-    response, err := s.apiClient.GetStemmingDictionaryWithResponse(ctx, s.dictionaryId)
-    if err != nil {
-        return nil, err
-    }
-    if response.JSON200 == nil {
-        return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
-    }
-    return response.JSON200, nil
+	response, err := s.apiClient.GetStemmingDictionaryWithResponse(ctx, s.dictionaryId)
+	if err != nil {
+		return nil, err
+	}
+	if response.JSON200 == nil {
+		return nil, &HTTPError{Status: response.StatusCode(), Body: response.Body}
+	}
+	return response.JSON200, nil
 }

--- a/typesense/test/dbhelpers_test.go
+++ b/typesense/test/dbhelpers_test.go
@@ -58,6 +58,7 @@ func expectedNewCollection(name string) *api.CollectionResponse {
 				Drop:     nil,
 				Store:    pointer.True(),
 				Stem:     pointer.False(),
+				StemDictionary: pointer.String(""),
 			},
 			{
 				Name:     "num_employees",
@@ -71,6 +72,7 @@ func expectedNewCollection(name string) *api.CollectionResponse {
 				Drop:     nil,
 				Store:    pointer.True(),
 				Stem:     pointer.False(),
+				StemDictionary: pointer.String(""),
 			},
 			{
 				Name:     "country",
@@ -84,6 +86,7 @@ func expectedNewCollection(name string) *api.CollectionResponse {
 				Drop:     nil,
 				Store:    pointer.True(),
 				Stem:     pointer.False(),
+				StemDictionary: pointer.String(""),
 			},
 		},
 		EnableNestedFields:  pointer.False(),

--- a/typesense/test/stemming_test.go
+++ b/typesense/test/stemming_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/v3/typesense/api"
+)
+
+func TestStemmingDictionary(t *testing.T) {
+    dictionaryId := fmt.Sprintf("dictionary_%d", time.Now().UnixNano())
+    words := []api.StemmingDictionaryWord{
+        {
+            Root: "exampleRoot1",
+            Word: "exampleWord1",
+        },
+        {
+            Root: "exampleRoot2",
+            Word: "exampleWord2",
+        },
+    }
+
+    t.Run("Upsert", func(t *testing.T) {
+        result, err := typesenseClient.Stemming().Dictionaries().Upsert(
+            context.Background(),
+            dictionaryId,
+            words,
+        )
+        require.NoError(t, err)
+        require.Len(t, result, len(words))
+    })
+
+    t.Run("Retrieve Single", func(t *testing.T) {
+        result, err := typesenseClient.Stemming().Dictionary(dictionaryId).Retrieve(context.Background())
+        require.NoError(t, err)
+        require.Equal(t, dictionaryId, result.Id)
+        // Convert result.Words to the same type for comparison
+        retrievedWords := make([]api.StemmingDictionaryWord, len(result.Words))
+        for i, w := range result.Words {
+            retrievedWords[i] = api.StemmingDictionaryWord{
+                Root: w.Root,
+                Word: w.Word,
+            }
+        }
+        require.Equal(t, words, retrievedWords)
+    })
+
+    t.Run("List All", func(t *testing.T) {
+        result, err := typesenseClient.Stemming().Dictionaries().Retrieve(context.Background())
+        require.NoError(t, err)
+        require.Contains(t, *result.JSON200.Dictionaries, dictionaryId)
+    })
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes significant updates to the Typesense API, including new features, schema modifications, and documentation updates. The most important changes are the addition of stemming dictionary support, new query parameters, and updates to the API version and documentation links.

### New Features:
* Added support for stemming dictionaries, including endpoints to list, retrieve, and import stemming dictionaries. (`typesense/api/generator/generator.yml`, `typesense/api/generator/openapi.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR537-R562) [[2]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR1556-R1582) [[3]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR3702-R3791) [[4]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1R1769-R1859)

### Schema Modifications:
* Introduced new fields such as `stem_dictionary`, `symbols_to_index`, `token_separators`, and `max_filter_by_candidates` to the schema. (`typesense/api/generator/generator.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR537-R562) [[2]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR1252-R1254)
* Added `SchemaChangeStatus` object to track schema change operations. (`typesense/api/generator/generator.yml`, `typesense/api/generator/openapi.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR918-R929) [[2]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1R1274-R1289)

### New Query Parameters:
* Added `truncate` and `max_filter_by_candidates` query parameters to various endpoints. (`typesense/api/generator/generator.yml`, `typesense/api/generator/openapi.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR2082-R2085) [[2]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR2583-R2586) [[3]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eR3385-R3388) [[4]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1R365-R367)

### API Version Update:
* Updated API version from `27.0` to `28.0`. (`typesense/api/generator/generator.yml`, `typesense/api/generator/openapi.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eL1586-R1658) [[2]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1L5-R5)

### Documentation Updates:
* Updated external documentation links to reflect the new API version `28.0`. (`typesense/api/generator/generator.yml`, `typesense/api/generator/openapi.yml`) [[1]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eL3733-R3923) [[2]](diffhunk://#diff-12308f355c779383163294ee96e54b9aa0d68ba506596e6fa1da34b298e7945eL3745-R3961) [[3]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1L31-R31) [[4]](diffhunk://#diff-8a684b9bf36cea31300c551ace52dfdebb1a04f8b987a4d3ad73a1df8fecb4e1L43-R68)
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
