### PR TITLE
feat(api): expose returned IDs when importing documents with return_id=true

### DIFF
--- a/typesense/api/types.go
+++ b/typesense/api/types.go
@@ -4,6 +4,7 @@ type ImportDocumentResponse struct {
 	Success  bool   `json:"success"`
 	Error    string `json:"error"`
 	Document string `json:"document"`
+	Id       string `json:"id"`
 }
 
 type StemmingDictionaryWord struct {

--- a/typesense/import_test.go
+++ b/typesense/import_test.go
@@ -204,10 +204,10 @@ func TestDocumentsImportWithTwoDocuments(t *testing.T) {
 	}
 	expectedBody := strings.NewReader(`{"id":"123","companyName":"Stark Industries","numEmployees":5215,"country":"USA"}` +
 		"\n" + `{"id":"125","companyName":"Stark Industries","numEmployees":5215,"country":"USA"}` + "\n")
-	expectedResultString := `{"success": true}` + "\n" + `{"success": false, "error": "Bad JSON.", "document": "[bad doc"}`
+	expectedResultString := `{"success": true, "id":"123"}` + "\n" + `{"success": false, "id":"125", "error": "Bad JSON.", "document": "[bad doc"}`
 	expectedResult := []*api.ImportDocumentResponse{
-		{Success: true},
-		{Success: false, Error: "Bad JSON.", Document: "[bad doc"},
+		{Success: true, Id: "123"},
+		{Success: false, Id: "125", Error: "Bad JSON.", Document: "[bad doc"},
 	}
 
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Change Summary

Adds the ability to inspect the ID returned when importing documents with the `return_id=true` flag.

https://typesense.org/docs/28.0/api/documents.html#returning-the-id-of-the-imported-documents

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
