### PR TITLE
fix: type signature for ImportDocumentResponse

### DIFF
--- a/typesense/api/types.go
+++ b/typesense/api/types.go
@@ -3,7 +3,7 @@ package api
 type ImportDocumentResponse struct {
 	Success  bool   `json:"success"`
 	Error    string `json:"error"`
-	Document string `json:"document"`
+	Document any    `json:"document"` // on success: map[string]interface{}; on error: string
 	Id       string `json:"id"`
 }
 


### PR DESCRIPTION
## Change Summary

When given `return_doc=true` in the query to the bulk import API, Typesense returns a valid JSON object in the `document` field of the response.

On failure (for example invalid JSON), the raw string from the request is echoed in the response instead.

This change makes the Go SDK compatible with that behavior.

I've also improved the implementation of `(*documents) Import()`. Previously, it ignored junk output appended to valid JSON. It now rejects anything but JSONL.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
