### PR TITLE
feat: add HybridSearchInfo field to SearchResultHit

### DIFF
--- a/typesense/api/client_gen.go
+++ b/typesense/api/client_gen.go
@@ -254,6 +254,25 @@ type ClientInterface interface {
 
 	MultiSearch(ctx context.Context, params *MultiSearchParams, body MultiSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RetrieveAllNLSearchModels request
+	RetrieveAllNLSearchModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateNLSearchModelWithBody request with any body
+	CreateNLSearchModelWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateNLSearchModel(ctx context.Context, body CreateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteNLSearchModel request
+	DeleteNLSearchModel(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrieveNLSearchModel request
+	RetrieveNLSearchModel(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateNLSearchModelWithBody request with any body
+	UpdateNLSearchModelWithBody(ctx context.Context, modelId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateNLSearchModel(ctx context.Context, modelId string, body UpdateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetSchemaChanges request
 	GetSchemaChanges(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1016,6 +1035,90 @@ func (c *Client) MultiSearchWithBody(ctx context.Context, params *MultiSearchPar
 
 func (c *Client) MultiSearch(ctx context.Context, params *MultiSearchParams, body MultiSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewMultiSearchRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrieveAllNLSearchModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrieveAllNLSearchModelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateNLSearchModelWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNLSearchModelRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateNLSearchModel(ctx context.Context, body CreateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateNLSearchModelRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteNLSearchModel(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteNLSearchModelRequest(c.Server, modelId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrieveNLSearchModel(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrieveNLSearchModelRequest(c.Server, modelId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateNLSearchModelWithBody(ctx context.Context, modelId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateNLSearchModelRequestWithBody(c.Server, modelId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateNLSearchModel(ctx context.Context, modelId string, body UpdateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateNLSearchModelRequest(c.Server, modelId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2896,6 +2999,38 @@ func NewSearchCollectionRequest(server string, collectionName string, params *Se
 		if params.MinLen2typo != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "min_len_2typo", runtime.ParamLocationQuery, *params.MinLen2typo); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NlModelId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "nl_model_id", runtime.ParamLocationQuery, *params.NlModelId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NlQuery != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "nl_query", runtime.ParamLocationQuery, *params.NlQuery); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -4921,6 +5056,38 @@ func NewMultiSearchRequestWithBody(server string, params *MultiSearchParams, con
 
 		}
 
+		if params.NlModelId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "nl_model_id", runtime.ParamLocationQuery, *params.NlModelId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.NlQuery != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "nl_query", runtime.ParamLocationQuery, *params.NlQuery); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.NumTypos != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "num_typos", runtime.ParamLocationQuery, *params.NumTypos); err != nil {
@@ -5389,6 +5556,188 @@ func NewMultiSearchRequestWithBody(server string, params *MultiSearchParams, con
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRetrieveAllNLSearchModelsRequest generates requests for RetrieveAllNLSearchModels
+func NewRetrieveAllNLSearchModelsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/nl_search_models")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateNLSearchModelRequest calls the generic CreateNLSearchModel builder with application/json body
+func NewCreateNLSearchModelRequest(server string, body CreateNLSearchModelJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateNLSearchModelRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateNLSearchModelRequestWithBody generates requests for CreateNLSearchModel with any type of body
+func NewCreateNLSearchModelRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/nl_search_models")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteNLSearchModelRequest generates requests for DeleteNLSearchModel
+func NewDeleteNLSearchModelRequest(server string, modelId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "modelId", runtime.ParamLocationPath, modelId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/nl_search_models/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRetrieveNLSearchModelRequest generates requests for RetrieveNLSearchModel
+func NewRetrieveNLSearchModelRequest(server string, modelId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "modelId", runtime.ParamLocationPath, modelId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/nl_search_models/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateNLSearchModelRequest calls the generic UpdateNLSearchModel builder with application/json body
+func NewUpdateNLSearchModelRequest(server string, modelId string, body UpdateNLSearchModelJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateNLSearchModelRequestWithBody(server, modelId, "application/json", bodyReader)
+}
+
+// NewUpdateNLSearchModelRequestWithBody generates requests for UpdateNLSearchModel with any type of body
+func NewUpdateNLSearchModelRequestWithBody(server string, modelId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "modelId", runtime.ParamLocationPath, modelId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/nl_search_models/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -6134,6 +6483,25 @@ type ClientWithResponsesInterface interface {
 	MultiSearchWithBodyWithResponse(ctx context.Context, params *MultiSearchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MultiSearchResponse, error)
 
 	MultiSearchWithResponse(ctx context.Context, params *MultiSearchParams, body MultiSearchJSONRequestBody, reqEditors ...RequestEditorFn) (*MultiSearchResponse, error)
+
+	// RetrieveAllNLSearchModelsWithResponse request
+	RetrieveAllNLSearchModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrieveAllNLSearchModelsResponse, error)
+
+	// CreateNLSearchModelWithBodyWithResponse request with any body
+	CreateNLSearchModelWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNLSearchModelResponse, error)
+
+	CreateNLSearchModelWithResponse(ctx context.Context, body CreateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNLSearchModelResponse, error)
+
+	// DeleteNLSearchModelWithResponse request
+	DeleteNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*DeleteNLSearchModelResponse, error)
+
+	// RetrieveNLSearchModelWithResponse request
+	RetrieveNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*RetrieveNLSearchModelResponse, error)
+
+	// UpdateNLSearchModelWithBodyWithResponse request with any body
+	UpdateNLSearchModelWithBodyWithResponse(ctx context.Context, modelId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateNLSearchModelResponse, error)
+
+	UpdateNLSearchModelWithResponse(ctx context.Context, modelId string, body UpdateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateNLSearchModelResponse, error)
 
 	// GetSchemaChangesWithResponse request
 	GetSchemaChangesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetSchemaChangesResponse, error)
@@ -7222,6 +7590,121 @@ func (r MultiSearchResponse) StatusCode() int {
 	return 0
 }
 
+type RetrieveAllNLSearchModelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]NLSearchModelSchema
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrieveAllNLSearchModelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrieveAllNLSearchModelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateNLSearchModelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *NLSearchModelSchema
+	JSON400      *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateNLSearchModelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateNLSearchModelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteNLSearchModelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *NLSearchModelDeleteSchema
+	JSON404      *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteNLSearchModelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteNLSearchModelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RetrieveNLSearchModelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *NLSearchModelSchema
+	JSON404      *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrieveNLSearchModelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrieveNLSearchModelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateNLSearchModelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *NLSearchModelSchema
+	JSON400      *ApiResponse
+	JSON404      *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateNLSearchModelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateNLSearchModelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetSchemaChangesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8086,6 +8569,67 @@ func (c *ClientWithResponses) MultiSearchWithResponse(ctx context.Context, param
 		return nil, err
 	}
 	return ParseMultiSearchResponse(rsp)
+}
+
+// RetrieveAllNLSearchModelsWithResponse request returning *RetrieveAllNLSearchModelsResponse
+func (c *ClientWithResponses) RetrieveAllNLSearchModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrieveAllNLSearchModelsResponse, error) {
+	rsp, err := c.RetrieveAllNLSearchModels(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrieveAllNLSearchModelsResponse(rsp)
+}
+
+// CreateNLSearchModelWithBodyWithResponse request with arbitrary body returning *CreateNLSearchModelResponse
+func (c *ClientWithResponses) CreateNLSearchModelWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateNLSearchModelResponse, error) {
+	rsp, err := c.CreateNLSearchModelWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateNLSearchModelResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateNLSearchModelWithResponse(ctx context.Context, body CreateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateNLSearchModelResponse, error) {
+	rsp, err := c.CreateNLSearchModel(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateNLSearchModelResponse(rsp)
+}
+
+// DeleteNLSearchModelWithResponse request returning *DeleteNLSearchModelResponse
+func (c *ClientWithResponses) DeleteNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*DeleteNLSearchModelResponse, error) {
+	rsp, err := c.DeleteNLSearchModel(ctx, modelId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteNLSearchModelResponse(rsp)
+}
+
+// RetrieveNLSearchModelWithResponse request returning *RetrieveNLSearchModelResponse
+func (c *ClientWithResponses) RetrieveNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...RequestEditorFn) (*RetrieveNLSearchModelResponse, error) {
+	rsp, err := c.RetrieveNLSearchModel(ctx, modelId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrieveNLSearchModelResponse(rsp)
+}
+
+// UpdateNLSearchModelWithBodyWithResponse request with arbitrary body returning *UpdateNLSearchModelResponse
+func (c *ClientWithResponses) UpdateNLSearchModelWithBodyWithResponse(ctx context.Context, modelId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateNLSearchModelResponse, error) {
+	rsp, err := c.UpdateNLSearchModelWithBody(ctx, modelId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateNLSearchModelResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateNLSearchModelWithResponse(ctx context.Context, modelId string, body UpdateNLSearchModelJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateNLSearchModelResponse, error) {
+	rsp, err := c.UpdateNLSearchModel(ctx, modelId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateNLSearchModelResponse(rsp)
 }
 
 // GetSchemaChangesWithResponse request returning *GetSchemaChangesResponse
@@ -9684,6 +10228,171 @@ func ParseMultiSearchResponse(rsp *http.Response) (*MultiSearchResponse, error) 
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetrieveAllNLSearchModelsResponse parses an HTTP response from a RetrieveAllNLSearchModelsWithResponse call
+func ParseRetrieveAllNLSearchModelsResponse(rsp *http.Response) (*RetrieveAllNLSearchModelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrieveAllNLSearchModelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []NLSearchModelSchema
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateNLSearchModelResponse parses an HTTP response from a CreateNLSearchModelWithResponse call
+func ParseCreateNLSearchModelResponse(rsp *http.Response) (*CreateNLSearchModelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateNLSearchModelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest NLSearchModelSchema
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteNLSearchModelResponse parses an HTTP response from a DeleteNLSearchModelWithResponse call
+func ParseDeleteNLSearchModelResponse(rsp *http.Response) (*DeleteNLSearchModelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteNLSearchModelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest NLSearchModelDeleteSchema
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetrieveNLSearchModelResponse parses an HTTP response from a RetrieveNLSearchModelWithResponse call
+func ParseRetrieveNLSearchModelResponse(rsp *http.Response) (*RetrieveNLSearchModelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrieveNLSearchModelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest NLSearchModelSchema
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateNLSearchModelResponse parses an HTTP response from a UpdateNLSearchModelWithResponse call
+func ParseUpdateNLSearchModelResponse(rsp *http.Response) (*UpdateNLSearchModelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateNLSearchModelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest NLSearchModelSchema
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	}
 

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -403,11 +403,6 @@ components:
         - drop
         - reject
       type: string
-    DocumentIndexParameters:
-      properties:
-        dirty_values:
-          $ref: '#/components/schemas/DirtyValues'
-      type: object
     DropTokensMode:
       description: |
         Dictates the direction in which the words in the query must be dropped when the original words in the query do not appear in any document. Values: right_to_left (default), left_to_right, both_sides:3 A note on both_sides:3 - for queries upto 3 tokens (words) in length, this mode will drop tokens from both sides and exhaustively rank all matching results. If query length is greater than 3 words, Typesense will just fallback to default behavior of right_to_left
@@ -416,11 +411,6 @@ components:
         - left_to_right
         - both_sides:3
       type: string
-    ErrorResponse:
-      properties:
-        message:
-          type: string
-      type: object
     FacetCounts:
       properties:
         counts:
@@ -876,11 +866,99 @@ components:
             $ref: '#/components/schemas/MultiSearchCollectionParameters'
           type: array
         union:
+          default: false
           description: When true, merges the search results from each search query into a single ordered set of hits.
           type: boolean
       required:
         - searches
       type: object
+    NLSearchModelBase:
+      properties:
+        access_token:
+          description: Access token for GCP Vertex AI
+          type: string
+        account_id:
+          description: Account ID for Cloudflare-specific models
+          type: string
+        api_key:
+          description: API key for the NL model service
+          type: string
+        api_url:
+          description: Custom API URL for the NL model service
+          type: string
+        api_version:
+          description: API version for the NL model service
+          type: string
+        client_id:
+          description: Client ID for GCP Vertex AI
+          type: string
+        client_secret:
+          description: Client secret for GCP Vertex AI
+          type: string
+        max_bytes:
+          description: Maximum number of bytes to process
+          type: integer
+        max_output_tokens:
+          description: Maximum output tokens for GCP Vertex AI
+          type: integer
+        model_name:
+          description: Name of the NL model to use
+          type: string
+        project_id:
+          description: Project ID for GCP Vertex AI
+          type: string
+        refresh_token:
+          description: Refresh token for GCP Vertex AI
+          type: string
+        region:
+          description: Region for GCP Vertex AI
+          type: string
+        stop_sequences:
+          description: Stop sequences for the NL model (Google-specific)
+          items:
+            type: string
+          type: array
+        system_prompt:
+          description: System prompt for the NL model
+          type: string
+        temperature:
+          description: Temperature parameter for the NL model
+          type: number
+        top_k:
+          description: Top-k parameter for the NL model (Google-specific)
+          type: integer
+        top_p:
+          description: Top-p parameter for the NL model (Google-specific)
+          type: number
+      type: object
+    NLSearchModelCreateSchema:
+      allOf:
+        - $ref: '#/components/schemas/NLSearchModelBase'
+        - properties:
+            id:
+              description: Optional ID for the NL search model
+              type: string
+          type: object
+    NLSearchModelDeleteSchema:
+      properties:
+        id:
+          description: ID of the deleted NL search model
+          type: string
+      required:
+        - id
+      type: object
+    NLSearchModelSchema:
+      allOf:
+        - $ref: '#/components/schemas/NLSearchModelCreateSchema'
+        - properties:
+            id:
+              description: ID of the NL search model
+              type: string
+          required:
+            - id
+          type: object
+    NLSearchModelUpdateSchema:
+      $ref: '#/components/schemas/NLSearchModelCreateSchema'
     PresetDeleteSchema:
       properties:
         name:
@@ -926,14 +1004,6 @@ components:
         validated_docs:
           description: Number of documents that have been validated
           type: integer
-      type: object
-    ScopedKeyParameters:
-      properties:
-        expires_at:
-          format: int64
-          type: integer
-        filter_by:
-          type: string
       type: object
     SearchGroupedHit:
       properties:
@@ -1260,6 +1330,12 @@ components:
           description: |
             Minimum word length for 2-typo correction to be applied. The value of num_typos is still treated as the maximum allowed typos.
           type: integer
+        nl_model_id:
+          description: The ID of the natural language model to use.
+          type: string
+        nl_query:
+          description: Whether to use natural language processing to parse the query.
+          type: boolean
         num_typos:
           description: |
             The number of typographical errors (1 or 2) that would be tolerated. Default: 2
@@ -1373,6 +1449,24 @@ components:
             The base64 encoded audio file in 16 khz 16-bit WAV format.
           type: string
       type: object
+    SearchRequestParams:
+      properties:
+        collection_name:
+          type: string
+        per_page:
+          type: integer
+        q:
+          type: string
+        voice_query:
+          properties:
+            transcribed_query:
+              type: string
+          type: object
+      required:
+        - collection_name
+        - q
+        - per_page
+      type: object
     SearchResult:
       properties:
         conversation:
@@ -1402,29 +1496,18 @@ components:
           description: The search result page number
           type: integer
         request_params:
-          properties:
-            collection_name:
-              type: string
-            per_page:
-              type: integer
-            q:
-              type: string
-            voice_query:
-              properties:
-                transcribed_query:
-                  type: string
-              type: object
-          required:
-            - collection_name
-            - q
-            - per_page
-          type: object
+          $ref: '#/components/schemas/SearchRequestParams'
         search_cutoff:
           description: Whether the search was cut off
           type: boolean
         search_time_ms:
           description: The number of milliseconds the search took
           type: integer
+        union_request_params:
+          description: Returned only for union query response.
+          items:
+            $ref: '#/components/schemas/SearchRequestParams'
+          type: array
       type: object
     SearchResultConversation:
       properties:
@@ -1474,6 +1557,17 @@ components:
           items:
             $ref: '#/components/schemas/SearchHighlight'
           type: array
+        hybrid_search_info:
+          description: Information about hybrid search scoring
+          properties:
+            rank_fusion_score:
+              description: Combined score from rank fusion of text and vector search
+              format: float
+              type: number
+          type: object
+        search_index:
+          description: Returned only for union query response. Indicates the index of the query which this document matched to.
+          type: integer
         text_match:
           format: int64
           type: integer
@@ -1500,14 +1594,6 @@ components:
           description: Distance between the query vector and matching document's vector value
           format: float
           type: number
-        hybrid_search_info:
-          type: object
-          description: Metadata for hybrid search when both keyword and vector search are used
-          properties:
-            rank_fusion_score:
-              type: number
-              format: float
-              description: Combined score from rank fusion of keyword and vector results
       type: object
     SearchSynonym:
       allOf:
@@ -1557,11 +1643,6 @@ components:
           x-go-type: '[]*SearchSynonym'
       required:
         - synonyms
-      type: object
-    SnapshotParameters:
-      properties:
-        snapshot_path:
-          type: string
       type: object
     StemmingDictionary:
       properties:
@@ -1664,6 +1745,9 @@ externalDocs:
   url: https://typesense.org
 info:
   description: An open source search engine for building delightful search experiences.
+  license:
+    name: GPL-3.0
+    url: https://opensource.org/licenses/GPL-3.0
   title: Typesense API
   version: "28.0"
 openapi: 3.0.3
@@ -2603,6 +2687,14 @@ paths:
           schema:
             type: integer
         - in: query
+          name: nl_model_id
+          schema:
+            type: string
+        - in: query
+          name: nl_query
+          schema:
+            type: boolean
+        - in: query
           name: num_typos
           schema:
             type: string
@@ -3029,6 +3121,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
           description: Bad request, see error message for details
+      summary: Create a conversation model
       tags:
         - conversations
   /conversations/models/{modelId}:
@@ -3405,6 +3498,14 @@ paths:
           schema:
             type: integer
         - in: query
+          name: nl_model_id
+          schema:
+            type: string
+        - in: query
+          name: nl_query
+          schema:
+            type: boolean
+        - in: query
           name: num_typos
           schema:
             type: string
@@ -3541,6 +3642,140 @@ paths:
       summary: send multiple search requests in a single HTTP request
       tags:
         - documents
+  /nl_search_models:
+    get:
+      description: Retrieve all NL search models.
+      operationId: retrieveAllNLSearchModels
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/NLSearchModelSchema'
+                type: array
+          description: List of all NL search models
+      summary: List all NL search models
+      tags:
+        - nl_search_models
+    post:
+      description: Create a new NL search model.
+      operationId: createNLSearchModel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NLSearchModelCreateSchema'
+        description: The NL search model to be created
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+          description: NL search model successfully created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: Bad request, see error message for details
+      summary: Create a NL search model
+      tags:
+        - nl_search_models
+  /nl_search_models/{modelId}:
+    delete:
+      description: Delete a specific NL search model by its ID.
+      operationId: deleteNLSearchModel
+      parameters:
+        - description: The ID of the NL search model to delete
+          in: path
+          name: modelId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelDeleteSchema'
+          description: NL search model successfully deleted
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: NL search model not found
+      summary: Delete a NL search model
+      tags:
+        - nl_search_models
+    get:
+      description: Retrieve a specific NL search model by its ID.
+      operationId: retrieveNLSearchModel
+      parameters:
+        - description: The ID of the NL search model to retrieve
+          in: path
+          name: modelId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+          description: NL search model fetched
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: NL search model not found
+      summary: Retrieve a NL search model
+      tags:
+        - nl_search_models
+    put:
+      description: Update an existing NL search model.
+      operationId: updateNLSearchModel
+      parameters:
+        - description: The ID of the NL search model to update
+          in: path
+          name: modelId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NLSearchModelUpdateSchema'
+        description: The NL search model fields to update
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+          description: NL search model successfully updated
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: Bad request, see error message for details
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+          description: NL search model not found
+      summary: Update a NL search model
+      tags:
+        - nl_search_models
   /operations/schema_changes:
     get:
       description: Returns the status of any ongoing schema change operations. If no schema changes are in progress, returns an empty response.
@@ -3691,7 +3926,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-          description: Bad request, see error message for details.
+          description: Bad request, see error message for details
       summary: Upserts a preset.
       tags:
         - presets
@@ -3911,6 +4146,19 @@ paths:
         - stopwords
 security:
   - api_key_header: []
+servers:
+  - description: Typesense Server
+    url: '{protocol}://{hostname}:{port}'
+    variables:
+      hostname:
+        default: localhost
+        description: The hostname of your Typesense server
+      port:
+        default: "8108"
+        description: The port of your Typesense server
+      protocol:
+        default: http
+        description: The protocol of your Typesense server
 tags:
   - description: A collection is defined by a schema
     externalDocs:
@@ -3969,3 +4217,8 @@ tags:
       description: Find out more
       url: https://typesense.org/docs/28.0/api/stemming.html
     name: stemming
+  - description: Manage NL search models
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/29.0/api/natural-language-search.html
+    name: nl_search_models

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -1500,6 +1500,14 @@ components:
           description: Distance between the query vector and matching document's vector value
           format: float
           type: number
+        hybrid_search_info:
+          type: object
+          description: Metadata for hybrid search when both keyword and vector search are used
+          properties:
+            rank_fusion_score:
+              type: number
+              format: float
+              description: Combined score from rank fusion of keyword and vector results
       type: object
     SearchSynonym:
       allOf:

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -3,6 +3,22 @@ info:
   title: Typesense API
   description: "An open source search engine for building delightful search experiences."
   version: '28.0'
+  license:
+    name: GPL-3.0
+    url: https://opensource.org/licenses/GPL-3.0
+servers:
+  - url: "{protocol}://{hostname}:{port}"
+    description: Typesense Server
+    variables:
+      protocol:
+        default: http
+        description: The protocol of your Typesense server
+      hostname:
+        default: localhost
+        description: The hostname of your Typesense server
+      port:
+        default: "8108"
+        description: The port of your Typesense server
 externalDocs:
   description: Find out more about Typsesense
   url: https://typesense.org
@@ -66,6 +82,12 @@ tags:
     externalDocs:
       description: Find out more
       url: https://typesense.org/docs/28.0/api/stemming.html
+  - name: nl_search_models
+    description: Manage NL search models
+    externalDocs:
+      description: Find out more
+      url: https://typesense.org/docs/29.0/api/natural-language-search.html
+
 paths:
   /collections:
     get:
@@ -930,6 +952,7 @@ paths:
       tags:
         - conversations
     post:
+      summary: Create a conversation model
       description: Create a Conversation Model
       operationId: createConversationModel
       requestBody:
@@ -1734,7 +1757,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PresetSchema'
         '400':
-          description: Bad request, see error message for details.
+          description: Bad request, see error message for details
           content:
             application/json:
               schema:
@@ -1857,6 +1880,141 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
+  /nl_search_models:
+    get:
+      tags:
+        - nl_search_models
+      summary: List all NL search models
+      description: Retrieve all NL search models.
+      operationId: retrieveAllNLSearchModels
+      responses:
+        '200':
+          description: List of all NL search models
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NLSearchModelSchema'
+    post:
+      tags:
+        - nl_search_models
+      summary: Create a NL search model
+      description: Create a new NL search model.
+      operationId: createNLSearchModel
+      requestBody:
+        description: The NL search model to be created
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NLSearchModelCreateSchema'
+        required: true
+      responses:
+        '201':
+          description: NL search model successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+        '400':
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+  /nl_search_models/{modelId}:
+    get:
+      tags:
+        - nl_search_models
+      summary: Retrieve a NL search model
+      description: Retrieve a specific NL search model by its ID.
+      operationId: retrieveNLSearchModel
+      parameters:
+        - name: modelId
+          in: path
+          description: The ID of the NL search model to retrieve
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: NL search model fetched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+        '404':
+          description: NL search model not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    put:
+      tags:
+        - nl_search_models
+      summary: Update a NL search model
+      description: Update an existing NL search model.
+      operationId: updateNLSearchModel
+      parameters:
+        - name: modelId
+          in: path
+          description: The ID of the NL search model to update
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The NL search model fields to update
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NLSearchModelUpdateSchema'
+        required: true
+      responses:
+        '200':
+          description: NL search model successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelSchema'
+        '400':
+          description: Bad request, see error message for details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        '404':
+          description: NL search model not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+    delete:
+      tags:
+        - nl_search_models
+      summary: Delete a NL search model
+      description: Delete a specific NL search model by its ID.
+      operationId: deleteNLSearchModel
+      parameters:
+        - name: modelId
+          in: path
+          description: The ID of the NL search model to delete
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: NL search model successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NLSearchModelDeleteSchema'
+        '404':
+          description: NL search model not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+
 components:
   schemas:
     CollectionSchema:
@@ -2156,25 +2314,32 @@ components:
           items:
             $ref: "#/components/schemas/SearchResultHit"
         request_params:
-          type: object
-          required:
-            - collection_name
-            - q
-            - per_page
-          properties:
-            collection_name:
-              type: string
-            q:
-              type: string
-            per_page:
-              type: integer
-            voice_query:
-              type: object
-              properties:
-                transcribed_query:
-                  type: string
+            $ref: "#/components/schemas/SearchRequestParams"
         conversation:
           $ref: "#/components/schemas/SearchResultConversation"
+        union_request_params:
+          type: array
+          description: Returned only for union query response.
+          items:
+            $ref: "#/components/schemas/SearchRequestParams"
+    SearchRequestParams:
+      type: object
+      required:
+        - collection_name
+        - q
+        - per_page
+      properties:
+        collection_name:
+          type: string
+        q:
+          type: string
+        per_page:
+          type: integer
+        voice_query:
+          type: object
+          properties:
+            transcribed_query:
+              type: string
     SearchResultConversation:
       type: object
       required:
@@ -2257,6 +2422,17 @@ components:
           type: number
           format: float
           description: Distance between the query vector and matching document's vector value
+        hybrid_search_info:
+          type: object
+          description: Information about hybrid search scoring
+          properties:
+            rank_fusion_score:
+              type: number
+              format: float
+              description: Combined score from rank fusion of text and vector search
+        search_index:
+          type: integer
+          description: Returned only for union query response. Indicates the index of the query which this document matched to.
       example:
         highlights:
           company_name:
@@ -2576,24 +2752,6 @@ components:
           x-go-type: "[]*ApiKey"
           items:
             $ref: "#/components/schemas/ApiKey"
-    ScopedKeyParameters:
-      type: object
-      properties:
-        filter_by:
-          type: string
-        expires_at:
-          type: integer
-          format: int64
-    SnapshotParameters:
-      type: object
-      properties:
-        snapshot_path:
-          type: string
-    ErrorResponse:
-      type: object
-      properties:
-        message:
-          type: string
     MultiSearchResult:
       type: object
       required:
@@ -2629,6 +2787,14 @@ components:
         query_by:
           description: A list of `string` fields that should be queried
             against. Multiple fields are separated with a comma.
+          type: string
+
+        nl_query:
+          description: Whether to use natural language processing to parse the query.
+          type: boolean
+
+        nl_model_id:
+          description: The ID of the natural language model to use.
           type: string
 
         query_by_weights:
@@ -3382,6 +3548,7 @@ components:
       properties:
         union:
           type: boolean
+          default: false
           description: When true, merges the search results from each search query into a single ordered set of hits.
         searches:
           type: array
@@ -3672,12 +3839,6 @@ components:
       properties:
         name:
           type: string
-    # client libraries already have .create, .upsert,... methods so we omit the `action` param
-    DocumentIndexParameters:
-      type: object
-      properties:
-        dirty_values:
-          $ref: "#/components/schemas/DirtyValues"
     DirtyValues:
       type: string
       enum: [coerce_or_reject, coerce_or_drop, drop, reject]
@@ -3783,6 +3944,98 @@ components:
                 type: string
                 description: The root form of the word
                 example: person
+    NLSearchModelBase:
+      type: object
+      properties:
+        model_name:
+          type: string
+          description: Name of the NL model to use
+        api_key:
+          type: string
+          description: API key for the NL model service
+        api_url:
+          type: string
+          description: Custom API URL for the NL model service
+        max_bytes:
+          type: integer
+          description: Maximum number of bytes to process
+        temperature:
+          type: number
+          description: Temperature parameter for the NL model
+        system_prompt:
+          type: string
+          description: System prompt for the NL model
+        top_p:
+          type: number
+          description: Top-p parameter for the NL model (Google-specific)
+        top_k:
+          type: integer
+          description: Top-k parameter for the NL model (Google-specific)
+        stop_sequences:
+          type: array
+          items:
+            type: string
+          description: Stop sequences for the NL model (Google-specific)
+        api_version:
+          type: string
+          description: API version for the NL model service
+        project_id:
+          type: string
+          description: Project ID for GCP Vertex AI
+        access_token:
+          type: string
+          description: Access token for GCP Vertex AI
+        refresh_token:
+          type: string
+          description: Refresh token for GCP Vertex AI
+        client_id:
+          type: string
+          description: Client ID for GCP Vertex AI
+        client_secret:
+          type: string
+          description: Client secret for GCP Vertex AI
+        region:
+          type: string
+          description: Region for GCP Vertex AI
+        max_output_tokens:
+          type: integer
+          description: Maximum output tokens for GCP Vertex AI
+        account_id:
+          type: string
+          description: Account ID for Cloudflare-specific models
+
+    NLSearchModelCreateSchema:
+      allOf:
+        - $ref: '#/components/schemas/NLSearchModelBase'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: Optional ID for the NL search model
+
+    NLSearchModelSchema:
+      allOf:
+        - $ref: '#/components/schemas/NLSearchModelCreateSchema'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              description: ID of the NL search model
+
+    NLSearchModelUpdateSchema:
+      $ref: '#/components/schemas/NLSearchModelCreateSchema'
+
+    NLSearchModelDeleteSchema:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: ID of the deleted NL search model
+
   securitySchemes:
     api_key_header:
       type: apiKey

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -1334,8 +1334,14 @@ type SearchResultHit struct {
 	Highlight *map[string]interface{} `json:"highlight,omitempty"`
 
 	// Highlights (Deprecated) Contains highlighted portions of the search fields
-	Highlights    *[]SearchHighlight `json:"highlights,omitempty"`
-	TextMatch     *int64             `json:"text_match,omitempty"`
+	Highlights *[]SearchHighlight `json:"highlights,omitempty"`
+
+	// HybridSearchInfo Metadata for hybrid search when both keyword and vector search are used
+	HybridSearchInfo *struct {
+		// RankFusionScore Combined score from rank fusion of keyword and vector results
+		RankFusionScore *float32 `json:"rank_fusion_score,omitempty"`
+	} `json:"hybrid_search_info,omitempty"`
+	TextMatch     *int64 `json:"text_match,omitempty"`
 	TextMatchInfo *struct {
 		BestFieldScore   *string `json:"best_field_score,omitempty"`
 		BestFieldWeight  *int    `json:"best_field_weight,omitempty"`

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -856,21 +856,17 @@ type MultiSearchResultItem struct {
 	OutOf *int `json:"out_of,omitempty"`
 
 	// Page The search result page number
-	Page          *int `json:"page,omitempty"`
-	RequestParams *struct {
-		CollectionName string `json:"collection_name"`
-		PerPage        int    `json:"per_page"`
-		Q              string `json:"q"`
-		VoiceQuery     *struct {
-			TranscribedQuery *string `json:"transcribed_query,omitempty"`
-		} `json:"voice_query,omitempty"`
-	} `json:"request_params,omitempty"`
+	Page          *int                 `json:"page,omitempty"`
+	RequestParams *SearchRequestParams `json:"request_params,omitempty"`
 
 	// SearchCutoff Whether the search was cut off
 	SearchCutoff *bool `json:"search_cutoff,omitempty"`
 
 	// SearchTimeMs The number of milliseconds the search took
 	SearchTimeMs *int `json:"search_time_ms,omitempty"`
+
+	// UnionRequestParams Returned only for union query response.
+	UnionRequestParams *[]SearchRequestParams `json:"union_request_params,omitempty"`
 }
 
 // MultiSearchSearchesParameter defines model for MultiSearchSearchesParameter.
@@ -880,6 +876,192 @@ type MultiSearchSearchesParameter struct {
 	// Union When true, merges the search results from each search query into a single ordered set of hits.
 	Union *bool `json:"union,omitempty"`
 }
+
+// NLSearchModelBase defines model for NLSearchModelBase.
+type NLSearchModelBase struct {
+	// AccessToken Access token for GCP Vertex AI
+	AccessToken *string `json:"access_token,omitempty"`
+
+	// AccountId Account ID for Cloudflare-specific models
+	AccountId *string `json:"account_id,omitempty"`
+
+	// ApiKey API key for the NL model service
+	ApiKey *string `json:"api_key,omitempty"`
+
+	// ApiUrl Custom API URL for the NL model service
+	ApiUrl *string `json:"api_url,omitempty"`
+
+	// ApiVersion API version for the NL model service
+	ApiVersion *string `json:"api_version,omitempty"`
+
+	// ClientId Client ID for GCP Vertex AI
+	ClientId *string `json:"client_id,omitempty"`
+
+	// ClientSecret Client secret for GCP Vertex AI
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	// MaxBytes Maximum number of bytes to process
+	MaxBytes *int `json:"max_bytes,omitempty"`
+
+	// MaxOutputTokens Maximum output tokens for GCP Vertex AI
+	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
+
+	// ModelName Name of the NL model to use
+	ModelName *string `json:"model_name,omitempty"`
+
+	// ProjectId Project ID for GCP Vertex AI
+	ProjectId *string `json:"project_id,omitempty"`
+
+	// RefreshToken Refresh token for GCP Vertex AI
+	RefreshToken *string `json:"refresh_token,omitempty"`
+
+	// Region Region for GCP Vertex AI
+	Region *string `json:"region,omitempty"`
+
+	// StopSequences Stop sequences for the NL model (Google-specific)
+	StopSequences *[]string `json:"stop_sequences,omitempty"`
+
+	// SystemPrompt System prompt for the NL model
+	SystemPrompt *string `json:"system_prompt,omitempty"`
+
+	// Temperature Temperature parameter for the NL model
+	Temperature *float32 `json:"temperature,omitempty"`
+
+	// TopK Top-k parameter for the NL model (Google-specific)
+	TopK *int `json:"top_k,omitempty"`
+
+	// TopP Top-p parameter for the NL model (Google-specific)
+	TopP *float32 `json:"top_p,omitempty"`
+}
+
+// NLSearchModelCreateSchema defines model for NLSearchModelCreateSchema.
+type NLSearchModelCreateSchema struct {
+	// AccessToken Access token for GCP Vertex AI
+	AccessToken *string `json:"access_token,omitempty"`
+
+	// AccountId Account ID for Cloudflare-specific models
+	AccountId *string `json:"account_id,omitempty"`
+
+	// ApiKey API key for the NL model service
+	ApiKey *string `json:"api_key,omitempty"`
+
+	// ApiUrl Custom API URL for the NL model service
+	ApiUrl *string `json:"api_url,omitempty"`
+
+	// ApiVersion API version for the NL model service
+	ApiVersion *string `json:"api_version,omitempty"`
+
+	// ClientId Client ID for GCP Vertex AI
+	ClientId *string `json:"client_id,omitempty"`
+
+	// ClientSecret Client secret for GCP Vertex AI
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	// Id Optional ID for the NL search model
+	Id *string `json:"id,omitempty"`
+
+	// MaxBytes Maximum number of bytes to process
+	MaxBytes *int `json:"max_bytes,omitempty"`
+
+	// MaxOutputTokens Maximum output tokens for GCP Vertex AI
+	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
+
+	// ModelName Name of the NL model to use
+	ModelName *string `json:"model_name,omitempty"`
+
+	// ProjectId Project ID for GCP Vertex AI
+	ProjectId *string `json:"project_id,omitempty"`
+
+	// RefreshToken Refresh token for GCP Vertex AI
+	RefreshToken *string `json:"refresh_token,omitempty"`
+
+	// Region Region for GCP Vertex AI
+	Region *string `json:"region,omitempty"`
+
+	// StopSequences Stop sequences for the NL model (Google-specific)
+	StopSequences *[]string `json:"stop_sequences,omitempty"`
+
+	// SystemPrompt System prompt for the NL model
+	SystemPrompt *string `json:"system_prompt,omitempty"`
+
+	// Temperature Temperature parameter for the NL model
+	Temperature *float32 `json:"temperature,omitempty"`
+
+	// TopK Top-k parameter for the NL model (Google-specific)
+	TopK *int `json:"top_k,omitempty"`
+
+	// TopP Top-p parameter for the NL model (Google-specific)
+	TopP *float32 `json:"top_p,omitempty"`
+}
+
+// NLSearchModelDeleteSchema defines model for NLSearchModelDeleteSchema.
+type NLSearchModelDeleteSchema struct {
+	// Id ID of the deleted NL search model
+	Id string `json:"id"`
+}
+
+// NLSearchModelSchema defines model for NLSearchModelSchema.
+type NLSearchModelSchema struct {
+	// AccessToken Access token for GCP Vertex AI
+	AccessToken *string `json:"access_token,omitempty"`
+
+	// AccountId Account ID for Cloudflare-specific models
+	AccountId *string `json:"account_id,omitempty"`
+
+	// ApiKey API key for the NL model service
+	ApiKey *string `json:"api_key,omitempty"`
+
+	// ApiUrl Custom API URL for the NL model service
+	ApiUrl *string `json:"api_url,omitempty"`
+
+	// ApiVersion API version for the NL model service
+	ApiVersion *string `json:"api_version,omitempty"`
+
+	// ClientId Client ID for GCP Vertex AI
+	ClientId *string `json:"client_id,omitempty"`
+
+	// ClientSecret Client secret for GCP Vertex AI
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	// Id ID of the NL search model
+	Id string `json:"id"`
+
+	// MaxBytes Maximum number of bytes to process
+	MaxBytes *int `json:"max_bytes,omitempty"`
+
+	// MaxOutputTokens Maximum output tokens for GCP Vertex AI
+	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
+
+	// ModelName Name of the NL model to use
+	ModelName *string `json:"model_name,omitempty"`
+
+	// ProjectId Project ID for GCP Vertex AI
+	ProjectId *string `json:"project_id,omitempty"`
+
+	// RefreshToken Refresh token for GCP Vertex AI
+	RefreshToken *string `json:"refresh_token,omitempty"`
+
+	// Region Region for GCP Vertex AI
+	Region *string `json:"region,omitempty"`
+
+	// StopSequences Stop sequences for the NL model (Google-specific)
+	StopSequences *[]string `json:"stop_sequences,omitempty"`
+
+	// SystemPrompt System prompt for the NL model
+	SystemPrompt *string `json:"system_prompt,omitempty"`
+
+	// Temperature Temperature parameter for the NL model
+	Temperature *float32 `json:"temperature,omitempty"`
+
+	// TopK Top-k parameter for the NL model (Google-specific)
+	TopK *int `json:"top_k,omitempty"`
+
+	// TopP Top-p parameter for the NL model (Google-specific)
+	TopP *float32 `json:"top_p,omitempty"`
+}
+
+// NLSearchModelUpdateSchema defines model for NLSearchModelUpdateSchema.
+type NLSearchModelUpdateSchema = NLSearchModelCreateSchema
 
 // PresetDeleteSchema defines model for PresetDeleteSchema.
 type PresetDeleteSchema struct {
@@ -1190,6 +1372,12 @@ type SearchParameters struct {
 	// MinLen2typo Minimum word length for 2-typo correction to be applied. The value of num_typos is still treated as the maximum allowed typos.
 	MinLen2typo *int `json:"min_len_2typo,omitempty"`
 
+	// NlModelId The ID of the natural language model to use.
+	NlModelId *string `json:"nl_model_id,omitempty"`
+
+	// NlQuery Whether to use natural language processing to parse the query.
+	NlQuery *bool `json:"nl_query,omitempty"`
+
 	// NumTypos The number of typographical errors (1 or 2) that would be tolerated. Default: 2
 	NumTypos *string `json:"num_typos,omitempty"`
 
@@ -1280,6 +1468,16 @@ type SearchParameters struct {
 	VoiceQuery *string `json:"voice_query,omitempty"`
 }
 
+// SearchRequestParams defines model for SearchRequestParams.
+type SearchRequestParams struct {
+	CollectionName string `json:"collection_name"`
+	PerPage        int    `json:"per_page"`
+	Q              string `json:"q"`
+	VoiceQuery     *struct {
+		TranscribedQuery *string `json:"transcribed_query,omitempty"`
+	} `json:"voice_query,omitempty"`
+}
+
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
 	Conversation *SearchResultConversation `json:"conversation,omitempty"`
@@ -1297,21 +1495,17 @@ type SearchResult struct {
 	OutOf *int `json:"out_of,omitempty"`
 
 	// Page The search result page number
-	Page          *int `json:"page,omitempty"`
-	RequestParams *struct {
-		CollectionName string `json:"collection_name"`
-		PerPage        int    `json:"per_page"`
-		Q              string `json:"q"`
-		VoiceQuery     *struct {
-			TranscribedQuery *string `json:"transcribed_query,omitempty"`
-		} `json:"voice_query,omitempty"`
-	} `json:"request_params,omitempty"`
+	Page          *int                 `json:"page,omitempty"`
+	RequestParams *SearchRequestParams `json:"request_params,omitempty"`
 
 	// SearchCutoff Whether the search was cut off
 	SearchCutoff *bool `json:"search_cutoff,omitempty"`
 
 	// SearchTimeMs The number of milliseconds the search took
 	SearchTimeMs *int `json:"search_time_ms,omitempty"`
+
+	// UnionRequestParams Returned only for union query response.
+	UnionRequestParams *[]SearchRequestParams `json:"union_request_params,omitempty"`
 }
 
 // SearchResultConversation defines model for SearchResultConversation.
@@ -1336,11 +1530,14 @@ type SearchResultHit struct {
 	// Highlights (Deprecated) Contains highlighted portions of the search fields
 	Highlights *[]SearchHighlight `json:"highlights,omitempty"`
 
-	// HybridSearchInfo Metadata for hybrid search when both keyword and vector search are used
+	// HybridSearchInfo Information about hybrid search scoring
 	HybridSearchInfo *struct {
-		// RankFusionScore Combined score from rank fusion of keyword and vector results
+		// RankFusionScore Combined score from rank fusion of text and vector search
 		RankFusionScore *float32 `json:"rank_fusion_score,omitempty"`
 	} `json:"hybrid_search_info,omitempty"`
+
+	// SearchIndex Returned only for union query response. Indicates the index of the query which this document matched to.
+	SearchIndex   *int   `json:"search_index,omitempty"`
 	TextMatch     *int64 `json:"text_match,omitempty"`
 	TextMatchInfo *struct {
 		BestFieldScore   *string `json:"best_field_score,omitempty"`
@@ -1532,6 +1729,8 @@ type SearchCollectionParams struct {
 	MaxFilterByCandidates              *int            `form:"max_filter_by_candidates,omitempty" json:"max_filter_by_candidates,omitempty"`
 	MinLen1typo                        *int            `form:"min_len_1typo,omitempty" json:"min_len_1typo,omitempty"`
 	MinLen2typo                        *int            `form:"min_len_2typo,omitempty" json:"min_len_2typo,omitempty"`
+	NlModelId                          *string         `form:"nl_model_id,omitempty" json:"nl_model_id,omitempty"`
+	NlQuery                            *bool           `form:"nl_query,omitempty" json:"nl_query,omitempty"`
 	NumTypos                           *string         `form:"num_typos,omitempty" json:"num_typos,omitempty"`
 	Offset                             *int            `form:"offset,omitempty" json:"offset,omitempty"`
 	OverrideTags                       *string         `form:"override_tags,omitempty" json:"override_tags,omitempty"`
@@ -1612,6 +1811,8 @@ type MultiSearchParams struct {
 	MaxFilterByCandidates              *int            `form:"max_filter_by_candidates,omitempty" json:"max_filter_by_candidates,omitempty"`
 	MinLen1typo                        *int            `form:"min_len_1typo,omitempty" json:"min_len_1typo,omitempty"`
 	MinLen2typo                        *int            `form:"min_len_2typo,omitempty" json:"min_len_2typo,omitempty"`
+	NlModelId                          *string         `form:"nl_model_id,omitempty" json:"nl_model_id,omitempty"`
+	NlQuery                            *bool           `form:"nl_query,omitempty" json:"nl_query,omitempty"`
 	NumTypos                           *string         `form:"num_typos,omitempty" json:"num_typos,omitempty"`
 	Offset                             *int            `form:"offset,omitempty" json:"offset,omitempty"`
 	OverrideTags                       *string         `form:"override_tags,omitempty" json:"override_tags,omitempty"`
@@ -1702,6 +1903,12 @@ type CreateKeyJSONRequestBody = ApiKeySchema
 
 // MultiSearchJSONRequestBody defines body for MultiSearch for application/json ContentType.
 type MultiSearchJSONRequestBody = MultiSearchSearchesParameter
+
+// CreateNLSearchModelJSONRequestBody defines body for CreateNLSearchModel for application/json ContentType.
+type CreateNLSearchModelJSONRequestBody = NLSearchModelCreateSchema
+
+// UpdateNLSearchModelJSONRequestBody defines body for UpdateNLSearchModel for application/json ContentType.
+type UpdateNLSearchModelJSONRequestBody = NLSearchModelUpdateSchema
 
 // UpsertPresetJSONRequestBody defines body for UpsertPreset for application/json ContentType.
 type UpsertPresetJSONRequestBody = PresetUpsertSchema

--- a/typesense/mocks/mock_client.go
+++ b/typesense/mocks/mock_client.go
@@ -443,6 +443,86 @@ func (mr *MockAPIClientInterfaceMockRecorder) CreateKeyWithResponse(ctx, body an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).CreateKeyWithResponse), varargs...)
 }
 
+// CreateNLSearchModel mocks base method.
+func (m *MockAPIClientInterface) CreateNLSearchModel(ctx context.Context, body api.CreateNLSearchModelJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateNLSearchModel", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNLSearchModel indicates an expected call of CreateNLSearchModel.
+func (mr *MockAPIClientInterfaceMockRecorder) CreateNLSearchModel(ctx, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNLSearchModel", reflect.TypeOf((*MockAPIClientInterface)(nil).CreateNLSearchModel), varargs...)
+}
+
+// CreateNLSearchModelWithBody mocks base method.
+func (m *MockAPIClientInterface) CreateNLSearchModelWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateNLSearchModelWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNLSearchModelWithBody indicates an expected call of CreateNLSearchModelWithBody.
+func (mr *MockAPIClientInterfaceMockRecorder) CreateNLSearchModelWithBody(ctx, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNLSearchModelWithBody", reflect.TypeOf((*MockAPIClientInterface)(nil).CreateNLSearchModelWithBody), varargs...)
+}
+
+// CreateNLSearchModelWithBodyWithResponse mocks base method.
+func (m *MockAPIClientInterface) CreateNLSearchModelWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*api.CreateNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateNLSearchModelWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.CreateNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNLSearchModelWithBodyWithResponse indicates an expected call of CreateNLSearchModelWithBodyWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) CreateNLSearchModelWithBodyWithResponse(ctx, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNLSearchModelWithBodyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).CreateNLSearchModelWithBodyWithResponse), varargs...)
+}
+
+// CreateNLSearchModelWithResponse mocks base method.
+func (m *MockAPIClientInterface) CreateNLSearchModelWithResponse(ctx context.Context, body api.CreateNLSearchModelJSONRequestBody, reqEditors ...api.RequestEditorFn) (*api.CreateNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateNLSearchModelWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.CreateNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNLSearchModelWithResponse indicates an expected call of CreateNLSearchModelWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) CreateNLSearchModelWithResponse(ctx, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNLSearchModelWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).CreateNLSearchModelWithResponse), varargs...)
+}
+
 // Debug mocks base method.
 func (m *MockAPIClientInterface) Debug(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -761,6 +841,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) DeleteKeyWithResponse(ctx, keyId a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, keyId}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).DeleteKeyWithResponse), varargs...)
+}
+
+// DeleteNLSearchModel mocks base method.
+func (m *MockAPIClientInterface) DeleteNLSearchModel(ctx context.Context, modelId string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteNLSearchModel", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNLSearchModel indicates an expected call of DeleteNLSearchModel.
+func (mr *MockAPIClientInterfaceMockRecorder) DeleteNLSearchModel(ctx, modelId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNLSearchModel", reflect.TypeOf((*MockAPIClientInterface)(nil).DeleteNLSearchModel), varargs...)
+}
+
+// DeleteNLSearchModelWithResponse mocks base method.
+func (m *MockAPIClientInterface) DeleteNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...api.RequestEditorFn) (*api.DeleteNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteNLSearchModelWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.DeleteNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNLSearchModelWithResponse indicates an expected call of DeleteNLSearchModelWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) DeleteNLSearchModelWithResponse(ctx, modelId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNLSearchModelWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).DeleteNLSearchModelWithResponse), varargs...)
 }
 
 // DeletePreset mocks base method.
@@ -1923,6 +2043,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAllConversationModelsWithR
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllConversationModelsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAllConversationModelsWithResponse), varargs...)
 }
 
+// RetrieveAllNLSearchModels mocks base method.
+func (m *MockAPIClientInterface) RetrieveAllNLSearchModels(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveAllNLSearchModels", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveAllNLSearchModels indicates an expected call of RetrieveAllNLSearchModels.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAllNLSearchModels(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllNLSearchModels", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAllNLSearchModels), varargs...)
+}
+
+// RetrieveAllNLSearchModelsWithResponse mocks base method.
+func (m *MockAPIClientInterface) RetrieveAllNLSearchModelsWithResponse(ctx context.Context, reqEditors ...api.RequestEditorFn) (*api.RetrieveAllNLSearchModelsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveAllNLSearchModelsWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RetrieveAllNLSearchModelsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveAllNLSearchModelsWithResponse indicates an expected call of RetrieveAllNLSearchModelsWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveAllNLSearchModelsWithResponse(ctx any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllNLSearchModelsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveAllNLSearchModelsWithResponse), varargs...)
+}
+
 // RetrieveAllPresets mocks base method.
 func (m *MockAPIClientInterface) RetrieveAllPresets(ctx context.Context, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
 	m.ctrl.T.Helper()
@@ -2121,6 +2281,46 @@ func (mr *MockAPIClientInterfaceMockRecorder) RetrieveMetricsWithResponse(ctx an
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveMetricsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveMetricsWithResponse), varargs...)
+}
+
+// RetrieveNLSearchModel mocks base method.
+func (m *MockAPIClientInterface) RetrieveNLSearchModel(ctx context.Context, modelId string, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveNLSearchModel", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveNLSearchModel indicates an expected call of RetrieveNLSearchModel.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveNLSearchModel(ctx, modelId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveNLSearchModel", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveNLSearchModel), varargs...)
+}
+
+// RetrieveNLSearchModelWithResponse mocks base method.
+func (m *MockAPIClientInterface) RetrieveNLSearchModelWithResponse(ctx context.Context, modelId string, reqEditors ...api.RequestEditorFn) (*api.RetrieveNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RetrieveNLSearchModelWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.RetrieveNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RetrieveNLSearchModelWithResponse indicates an expected call of RetrieveNLSearchModelWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) RetrieveNLSearchModelWithResponse(ctx, modelId any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveNLSearchModelWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).RetrieveNLSearchModelWithResponse), varargs...)
 }
 
 // RetrievePreset mocks base method.
@@ -2641,6 +2841,86 @@ func (mr *MockAPIClientInterfaceMockRecorder) UpdateDocumentsWithResponse(ctx, c
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, collectionName, params, body}, reqEditors...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentsWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).UpdateDocumentsWithResponse), varargs...)
+}
+
+// UpdateNLSearchModel mocks base method.
+func (m *MockAPIClientInterface) UpdateNLSearchModel(ctx context.Context, modelId string, body api.UpdateNLSearchModelJSONRequestBody, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateNLSearchModel", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNLSearchModel indicates an expected call of UpdateNLSearchModel.
+func (mr *MockAPIClientInterfaceMockRecorder) UpdateNLSearchModel(ctx, modelId, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNLSearchModel", reflect.TypeOf((*MockAPIClientInterface)(nil).UpdateNLSearchModel), varargs...)
+}
+
+// UpdateNLSearchModelWithBody mocks base method.
+func (m *MockAPIClientInterface) UpdateNLSearchModelWithBody(ctx context.Context, modelId, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateNLSearchModelWithBody", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNLSearchModelWithBody indicates an expected call of UpdateNLSearchModelWithBody.
+func (mr *MockAPIClientInterfaceMockRecorder) UpdateNLSearchModelWithBody(ctx, modelId, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNLSearchModelWithBody", reflect.TypeOf((*MockAPIClientInterface)(nil).UpdateNLSearchModelWithBody), varargs...)
+}
+
+// UpdateNLSearchModelWithBodyWithResponse mocks base method.
+func (m *MockAPIClientInterface) UpdateNLSearchModelWithBodyWithResponse(ctx context.Context, modelId, contentType string, body io.Reader, reqEditors ...api.RequestEditorFn) (*api.UpdateNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId, contentType, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateNLSearchModelWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.UpdateNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNLSearchModelWithBodyWithResponse indicates an expected call of UpdateNLSearchModelWithBodyWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) UpdateNLSearchModelWithBodyWithResponse(ctx, modelId, contentType, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId, contentType, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNLSearchModelWithBodyWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).UpdateNLSearchModelWithBodyWithResponse), varargs...)
+}
+
+// UpdateNLSearchModelWithResponse mocks base method.
+func (m *MockAPIClientInterface) UpdateNLSearchModelWithResponse(ctx context.Context, modelId string, body api.UpdateNLSearchModelJSONRequestBody, reqEditors ...api.RequestEditorFn) (*api.UpdateNLSearchModelResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, modelId, body}
+	for _, a := range reqEditors {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateNLSearchModelWithResponse", varargs...)
+	ret0, _ := ret[0].(*api.UpdateNLSearchModelResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNLSearchModelWithResponse indicates an expected call of UpdateNLSearchModelWithResponse.
+func (mr *MockAPIClientInterfaceMockRecorder) UpdateNLSearchModelWithResponse(ctx, modelId, body any, reqEditors ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, modelId, body}, reqEditors...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNLSearchModelWithResponse", reflect.TypeOf((*MockAPIClientInterface)(nil).UpdateNLSearchModelWithResponse), varargs...)
 }
 
 // UpsertAlias mocks base method.


### PR DESCRIPTION
Add a new HybridSearchInfo field to the SearchResultHit struct to support hybrid search metadata. This field includes rank_fusion_score for combined scoring from keyword and vector search results.
