### PR TITLE
Add support for custom http.Client via ClientOption

### DIFF
--- a/typesense/client_test.go
+++ b/typesense/client_test.go
@@ -1,6 +1,7 @@
 package typesense
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -235,6 +236,19 @@ func TestClientConfigOptions(t *testing.T) {
 					reflect.ValueOf(onStateChange).Pointer(),
 					reflect.ValueOf(client.apiConfig.CircuitBreakerOnStateChange).Pointer(),
 					"onStateChange is not valid")
+				assert.NotNil(t, client.apiClient)
+			},
+		},
+		{
+			name: "WithCustomHTTPClient",
+			options: []ClientOption{
+				WithCustomHTTPClient(&http.Client{
+					Timeout: 10 * time.Second,
+				}),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.NotNil(t, client.apiConfig.CustomHTTPClient)
+				assert.Equal(t, 10*time.Second, client.apiConfig.CustomHTTPClient.Timeout)
 				assert.NotNil(t, client.apiClient)
 			},
 		},


### PR DESCRIPTION
## Change Summary
This PR adds support for injecting a custom [http.Client](vscode-file://vscode-app/c:/Users/LUIZBERILOCASEMIROQU/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) into the Typesense Go SDK via a new ClientOption (WithCustomHTTPClient).
This allows users to instrument Typesense HTTP requests with observability tools such as OpenTelemetry, enabling distributed tracing and advanced monitoring.

Added CustomHTTPClient field to ClientConfig
Created WithCustomHTTPClient option for NewClient
Modified client initialization to use the custom client if provided

## PR Checklist
Added CustomHTTPClient field to ClientConfig
Created WithCustomHTTPClient option for NewClient
Modified client initialization to use the custom client if provided
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
