### PR TITLE
Map hits Field in MultiSearchResult

### DIFF
--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -1075,6 +1075,10 @@ components:
           items:
             $ref: '#/components/schemas/MultiSearchResultItem'
           type: array
+        hits:
+          items:
+            $ref: '#/components/schemas/SearchResultHit'
+          type: array
       required:
         - results
       type: object

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -3043,6 +3043,10 @@ components:
             $ref: "#/components/schemas/MultiSearchResultItem"
         conversation:
           $ref: "#/components/schemas/SearchResultConversation"
+        hits:
+          items:
+            $ref: '#/components/schemas/SearchResultHit'
+          type: array
     MultiSearchResultItem:
       allOf:
       - $ref: "#/components/schemas/SearchResult"

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -1049,6 +1049,7 @@ type MultiSearchParameters struct {
 // MultiSearchResult defines model for MultiSearchResult.
 type MultiSearchResult struct {
 	Conversation *SearchResultConversation `json:"conversation,omitempty"`
+	Hits         *[]SearchResultHit        `json:"hits,omitempty"`
 	Results      []MultiSearchResultItem   `json:"results"`
 }
 


### PR DESCRIPTION
## Change Summary
Added support for the hits field in MultiSearchResult to handle union multi-search responses from the Typesense server.
Now, when Union: true is set, search results are accessible via the Hits property in the response struct.

Closes #204 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
