### PR TITLE
Add async reference support

### DIFF
--- a/typesense/analytics_rule_test.go
+++ b/typesense/analytics_rule_test.go
@@ -13,7 +13,7 @@ import (
 func TestAnalyticsRuleRetrieve(t *testing.T) {
 	expectedData := &api.AnalyticsRule{
 		Name:       "test_rule",
-		Type:       api.AnalyticsRuleTypeCounter,
+		Type:       api.Counter,
 		Collection: "test_collection",
 		EventType:  "click",
 		Params: &api.AnalyticsRuleCreateParams{

--- a/typesense/analytics_rules_test.go
+++ b/typesense/analytics_rules_test.go
@@ -15,7 +15,7 @@ func TestAnalyticsRulesRetrieve(t *testing.T) {
 	expectedData := []*api.AnalyticsRule{
 		{
 			Name:       "test_rule_1",
-			Type:       api.AnalyticsRuleTypeCounter,
+			Type:       api.Counter,
 			Collection: "test_collection",
 			EventType:  "click",
 			Params: &api.AnalyticsRuleCreateParams{
@@ -54,7 +54,7 @@ func TestAnalyticsRulesCreate(t *testing.T) {
 	createData := []*api.AnalyticsRuleCreate{
 		{
 			Name:       "test_rule",
-			Type:       api.AnalyticsRuleCreateTypeCounter,
+			Type:       api.Counter,
 			Collection: "test_collection",
 			EventType:  "click",
 			Params: &api.AnalyticsRuleCreateParams{
@@ -67,7 +67,7 @@ func TestAnalyticsRulesCreate(t *testing.T) {
 	expectedData := []*api.AnalyticsRule{
 		{
 			Name:       "test_rule",
-			Type:       api.AnalyticsRuleTypeCounter,
+			Type:       api.Counter,
 			Collection: "test_collection",
 			EventType:  "click",
 			Params: &api.AnalyticsRuleCreateParams{

--- a/typesense/api/client_gen.go
+++ b/typesense/api/client_gen.go
@@ -8311,7 +8311,7 @@ func (r DeleteCurationSetResponse) StatusCode() int {
 type RetrieveCurationSetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CurationSetRetrieveSchema
+	JSON200      *CurationSetSchema
 	JSON404      *ApiResponse
 }
 
@@ -9178,7 +9178,7 @@ func (r DeleteSynonymSetResponse) StatusCode() int {
 type RetrieveSynonymSetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *SynonymSetRetrieveSchema
+	JSON200      *SynonymSetSchema
 	JSON404      *ApiResponse
 }
 
@@ -11336,7 +11336,7 @@ func ParseRetrieveCurationSetResponse(rsp *http.Response) (*RetrieveCurationSetR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CurationSetRetrieveSchema
+		var dest CurationSetSchema
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -12505,7 +12505,7 @@ func ParseRetrieveSynonymSetResponse(rsp *http.Response) (*RetrieveSynonymSetRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest SynonymSetRetrieveSchema
+		var dest SynonymSetSchema
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/typesense/api/generator/generator.yml
+++ b/typesense/api/generator/generator.yml
@@ -126,12 +126,7 @@ components:
         rule_tag:
           type: string
         type:
-          enum:
-            - popular_queries
-            - nohits_queries
-            - counter
-            - log
-          type: string
+          $ref: '#/components/schemas/AnalyticsRuleType'
       required:
         - name
         - type
@@ -157,6 +152,13 @@ components:
         weight:
           type: integer
       type: object
+    AnalyticsRuleType:
+      enum:
+        - popular_queries
+        - nohits_queries
+        - counter
+        - log
+      type: string
     AnalyticsRuleUpdate:
       description: Fields allowed to update on an analytics rule
       properties:
@@ -607,8 +609,6 @@ components:
       required:
         - name
       type: object
-    CurationSetRetrieveSchema:
-      $ref: '#/components/schemas/CurationSetCreateSchema'
     CurationSetSchema:
       allOf:
         - $ref: '#/components/schemas/CurationSetCreateSchema'
@@ -672,6 +672,10 @@ components:
       type: object
     Field:
       properties:
+        async_reference:
+          description: |
+            Allow documents to be indexed successfully even when the referenced document doesn't exist yet.
+          type: boolean
         drop:
           example: true
           type: boolean
@@ -1863,10 +1867,17 @@ components:
         - id
       type: object
     SynonymItemSchema:
+      allOf:
+        - properties:
+            id:
+              description: Unique identifier for the synonym item
+              type: string
+          required:
+            - id
+          type: object
+        - $ref: '#/components/schemas/SynonymItemUpsertSchema'
+    SynonymItemUpsertSchema:
       properties:
-        id:
-          description: Unique identifier for the synonym item
-          type: string
         locale:
           description: Locale for the synonym, leave blank to use the standard tokenizer
           type: string
@@ -1884,7 +1895,6 @@ components:
             type: string
           type: array
       required:
-        - id
         - synonyms
       type: object
     SynonymSetCreateSchema:
@@ -1905,8 +1915,6 @@ components:
       required:
         - name
       type: object
-    SynonymSetRetrieveSchema:
-      $ref: '#/components/schemas/SynonymSetCreateSchema'
     SynonymSetSchema:
       allOf:
         - $ref: '#/components/schemas/SynonymSetCreateSchema'
@@ -2179,7 +2187,7 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/AnalyticsRule'
                   - items:
-                      anyOf:
+                      oneOf:
                         - $ref: '#/components/schemas/AnalyticsRule'
                         - properties:
                             error:
@@ -3162,7 +3170,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessStatus'
-          description: Compacting the on-disk database succeeded.
+          description: Toggle Slow Request Log database succeeded.
       summary: Toggle Slow Request Log
       tags:
         - operations
@@ -3333,7 +3341,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CurationSetRetrieveSchema'
+                $ref: '#/components/schemas/CurationSetSchema'
           description: Curation set fetched
         "404":
           content:
@@ -4557,7 +4565,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SynonymSetRetrieveSchema'
+                $ref: '#/components/schemas/SynonymSetSchema'
           description: Synonym set fetched
         "404":
           content:
@@ -4715,7 +4723,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SynonymItemSchema'
+              $ref: '#/components/schemas/SynonymItemUpsertSchema'
         description: The synonym item to be created/updated
         required: true
       responses:

--- a/typesense/api/generator/openapi.yml
+++ b/typesense/api/generator/openapi.yml
@@ -495,14 +495,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SynonymSetRetrieveSchema"
+                $ref: "#/components/schemas/SynonymSetSchema"
         "404":
           description: Synonym set not found
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiResponse"
-    
+
     put:
       tags:
         - synonyms
@@ -650,7 +650,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SynonymItemSchema"
+              $ref: "#/components/schemas/SynonymItemUpsertSchema"
         required: true
       responses:
         "200":
@@ -735,7 +735,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CurationSetRetrieveSchema"
+                $ref: "#/components/schemas/CurationSetSchema"
         "404":
           description: Curation set not found
           content:
@@ -1647,7 +1647,7 @@ paths:
                 {"log-slow-requests-time-ms": 2000}
       responses:
         '200':
-          description: Compacting the on-disk database succeeded.
+          description: Toggle Slow Request Log database succeeded.
           content:
             application/json:
               schema:
@@ -1805,7 +1805,7 @@ paths:
                   - $ref: "#/components/schemas/AnalyticsRule"
                   - type: array
                     items:
-                      anyOf:
+                      oneOf:
                         - $ref: "#/components/schemas/AnalyticsRule"
                         - type: object
                           properties:
@@ -2565,7 +2565,7 @@ components:
         async_reference:
           type: boolean
           description: >
-            When set to true, documents will be indexed successfully even when the referenced document doesn't exist yet. The resolution of references will happen automatically when the referenced documents get indexed later.
+            Allow documents to be indexed successfully even when the referenced document doesn't exist yet.
         num_dim:
           type: integer
           example: 256
@@ -3979,8 +3979,7 @@ components:
         name:
           type: string
         type:
-          type: string
-          enum: [popular_queries, nohits_queries, counter, log]
+          $ref: "#/components/schemas/AnalyticsRuleType"
         collection:
           type: string
         event_type:
@@ -4005,6 +4004,9 @@ components:
               type: string
             weight:
               type: integer
+    AnalyticsRuleType:
+      type: string
+      enum: [popular_queries, nohits_queries, counter, log]
     AnalyticsRuleUpdate:
       type: object
       description: Fields allowed to update on an analytics rule
@@ -4045,7 +4047,7 @@ components:
         query_counter_events: { type: integer }
         doc_log_events: { type: integer }
         doc_counter_events: { type: integer }
-    
+
     APIStatsResponse:
       type: object
       properties:
@@ -4368,15 +4370,11 @@ components:
           type: string
           description: ID of the deleted NL search model
 
-    SynonymItemSchema:
+    SynonymItemUpsertSchema:
       type: object
       required:
-        - id
         - synonyms
       properties:
-        id:
-          type: string
-          description: Unique identifier for the synonym item
         synonyms:
           type: array
           description: Array of words that should be considered as synonyms
@@ -4393,6 +4391,17 @@ components:
           description: By default, special characters are dropped from synonyms. Use this attribute to specify which special characters should be indexed as is
           items:
             type: string
+
+    SynonymItemSchema:
+      allOf:
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              description: Unique identifier for the synonym item
+        - $ref: "#/components/schemas/SynonymItemUpsertSchema"
 
     SynonymSetCreateSchema:
       type: object
@@ -4426,9 +4435,6 @@ components:
           description: Array of synonym sets
           items:
             $ref: "#/components/schemas/SynonymSetSchema"
-
-    SynonymSetRetrieveSchema:
-      $ref: "#/components/schemas/SynonymSetCreateSchema"
 
     SynonymSetDeleteSchema:
       type: object
@@ -4589,9 +4595,6 @@ components:
         id:
           type: string
           description: document id that should be excluded from the search results.
-
-    CurationSetRetrieveSchema:
-      $ref: '#/components/schemas/CurationSetCreateSchema'
 
     CurationSetDeleteSchema:
       type: object

--- a/typesense/api/types_gen.go
+++ b/typesense/api/types_gen.go
@@ -15,18 +15,10 @@ const (
 
 // Defines values for AnalyticsRuleType.
 const (
-	AnalyticsRuleTypeCounter        AnalyticsRuleType = "counter"
-	AnalyticsRuleTypeLog            AnalyticsRuleType = "log"
-	AnalyticsRuleTypeNohitsQueries  AnalyticsRuleType = "nohits_queries"
-	AnalyticsRuleTypePopularQueries AnalyticsRuleType = "popular_queries"
-)
-
-// Defines values for AnalyticsRuleCreateType.
-const (
-	AnalyticsRuleCreateTypeCounter        AnalyticsRuleCreateType = "counter"
-	AnalyticsRuleCreateTypeLog            AnalyticsRuleCreateType = "log"
-	AnalyticsRuleCreateTypeNohitsQueries  AnalyticsRuleCreateType = "nohits_queries"
-	AnalyticsRuleCreateTypePopularQueries AnalyticsRuleCreateType = "popular_queries"
+	Counter        AnalyticsRuleType = "counter"
+	Log            AnalyticsRuleType = "log"
+	NohitsQueries  AnalyticsRuleType = "nohits_queries"
+	PopularQueries AnalyticsRuleType = "popular_queries"
 )
 
 // Defines values for CurationRuleMatch.
@@ -125,9 +117,6 @@ type AnalyticsRule struct {
 	Type       AnalyticsRuleType          `json:"type"`
 }
 
-// AnalyticsRuleType defines model for AnalyticsRule.Type.
-type AnalyticsRuleType string
-
 // AnalyticsRuleCreate defines model for AnalyticsRuleCreate.
 type AnalyticsRuleCreate struct {
 	Collection string                     `json:"collection"`
@@ -135,11 +124,8 @@ type AnalyticsRuleCreate struct {
 	Name       string                     `json:"name"`
 	Params     *AnalyticsRuleCreateParams `json:"params,omitempty"`
 	RuleTag    *string                    `json:"rule_tag,omitempty"`
-	Type       AnalyticsRuleCreateType    `json:"type"`
+	Type       AnalyticsRuleType          `json:"type"`
 }
-
-// AnalyticsRuleCreateType defines model for AnalyticsRuleCreate.Type.
-type AnalyticsRuleCreateType string
 
 // AnalyticsRuleCreateParams defines model for AnalyticsRuleCreateParams.
 type AnalyticsRuleCreateParams struct {
@@ -151,6 +137,9 @@ type AnalyticsRuleCreateParams struct {
 	MetaFields            *[]string `json:"meta_fields,omitempty"`
 	Weight                *int      `json:"weight,omitempty"`
 }
+
+// AnalyticsRuleType defines model for AnalyticsRuleType.
+type AnalyticsRuleType string
 
 // AnalyticsRuleUpdate Fields allowed to update on an analytics rule
 type AnalyticsRuleUpdate struct {
@@ -537,9 +526,6 @@ type CurationSetDeleteSchema struct {
 	Name string `json:"name"`
 }
 
-// CurationSetRetrieveSchema defines model for CurationSetRetrieveSchema.
-type CurationSetRetrieveSchema = CurationSetCreateSchema
-
 // CurationSetSchema defines model for CurationSetSchema.
 type CurationSetSchema struct {
 	// Description Optional description for the curation set
@@ -579,25 +565,24 @@ type FacetCountsStats struct {
 
 // Field defines model for Field.
 type Field struct {
-	Drop     *bool       `json:"drop,omitempty"`
-	Embed    *FieldEmbed `json:"embed,omitempty"`
-	Facet    *bool       `json:"facet,omitempty"`
-	Index    *bool       `json:"index,omitempty"`
-	Infix    *bool       `json:"infix,omitempty"`
-	Locale   *string     `json:"locale,omitempty"`
-	Name     string      `json:"name"`
-	NumDim   *int        `json:"num_dim,omitempty"`
-	Optional *bool       `json:"optional,omitempty"`
+	// AsyncReference Allow documents to be indexed successfully even when the referenced document doesn't exist yet.
+	AsyncReference *bool       `json:"async_reference,omitempty"`
+	Drop           *bool       `json:"drop,omitempty"`
+	Embed          *FieldEmbed `json:"embed,omitempty"`
+	Facet          *bool       `json:"facet,omitempty"`
+	Index          *bool       `json:"index,omitempty"`
+	Infix          *bool       `json:"infix,omitempty"`
+	Locale         *string     `json:"locale,omitempty"`
+	Name           string      `json:"name"`
+	NumDim         *int        `json:"num_dim,omitempty"`
+	Optional       *bool       `json:"optional,omitempty"`
 
 	// RangeIndex Enables an index optimized for range filtering on numerical fields (e.g. rating:>3.5). Default: false.
 	RangeIndex *bool `json:"range_index,omitempty"`
 
 	// Reference Name of a field in another collection that should be linked to this collection so that it can be joined during query.
 	Reference *string `json:"reference,omitempty"`
-
-	// AsyncReference When set to true, documents will be indexed successfully even when the referenced document doesn't exist yet. The resolution of references will happen automatically when the referenced documents get indexed later.
-	AsyncReference *bool `json:"async_reference,omitempty"`
-	Sort           *bool `json:"sort,omitempty"`
+	Sort      *bool   `json:"sort,omitempty"`
 
 	// Stem Values are stemmed before indexing in-memory. Default: false.
 	Stem *bool `json:"stem,omitempty"`
@@ -1743,6 +1728,21 @@ type SynonymItemSchema struct {
 	Synonyms []string `json:"synonyms"`
 }
 
+// SynonymItemUpsertSchema defines model for SynonymItemUpsertSchema.
+type SynonymItemUpsertSchema struct {
+	// Locale Locale for the synonym, leave blank to use the standard tokenizer
+	Locale *string `json:"locale,omitempty"`
+
+	// Root For 1-way synonyms, indicates the root word that words in the synonyms parameter map to
+	Root *string `json:"root,omitempty"`
+
+	// SymbolsToIndex By default, special characters are dropped from synonyms. Use this attribute to specify which special characters should be indexed as is
+	SymbolsToIndex *[]string `json:"symbols_to_index,omitempty"`
+
+	// Synonyms Array of words that should be considered as synonyms
+	Synonyms []string `json:"synonyms"`
+}
+
 // SynonymSetCreateSchema defines model for SynonymSetCreateSchema.
 type SynonymSetCreateSchema struct {
 	// Items Array of synonym items
@@ -1754,9 +1754,6 @@ type SynonymSetDeleteSchema struct {
 	// Name Name of the deleted synonym set
 	Name string `json:"name"`
 }
-
-// SynonymSetRetrieveSchema defines model for SynonymSetRetrieveSchema.
-type SynonymSetRetrieveSchema = SynonymSetCreateSchema
 
 // SynonymSetSchema defines model for SynonymSetSchema.
 type SynonymSetSchema struct {
@@ -2095,7 +2092,7 @@ type UpsertStopwordsSetJSONRequestBody = StopwordsSetUpsertSchema
 type UpsertSynonymSetJSONRequestBody = SynonymSetCreateSchema
 
 // UpsertSynonymSetItemJSONRequestBody defines body for UpsertSynonymSetItem for application/json ContentType.
-type UpsertSynonymSetItemJSONRequestBody = SynonymItemSchema
+type UpsertSynonymSetItemJSONRequestBody = SynonymItemUpsertSchema
 
 // AsSearchParameters returns the union data inside the PresetSchema_Value as a SearchParameters
 func (t PresetSchema_Value) AsSearchParameters() (SearchParameters, error) {

--- a/typesense/curation_set.go
+++ b/typesense/curation_set.go
@@ -9,7 +9,7 @@ import (
 // CurationSetInterface is a type for individual Curation Set API operations
 type CurationSetInterface interface {
 	// Retrieve a single curation set
-	Retrieve(ctx context.Context) (*api.CurationSetRetrieveSchema, error)
+	Retrieve(ctx context.Context) (*api.CurationSetSchema, error)
 	// Update a curation set
 	Upsert(ctx context.Context, curationSetSchema *api.CurationSetCreateSchema) (*api.CurationSetSchema, error)
 	// Delete a curation set
@@ -22,7 +22,7 @@ type curationSet struct {
 	curationSetName string
 }
 
-func (c *curationSet) Retrieve(ctx context.Context) (*api.CurationSetRetrieveSchema, error) {
+func (c *curationSet) Retrieve(ctx context.Context) (*api.CurationSetSchema, error) {
 	response, err := c.apiClient.RetrieveCurationSetWithResponse(ctx, c.curationSetName)
 	if err != nil {
 		return nil, err

--- a/typesense/synonym_set.go
+++ b/typesense/synonym_set.go
@@ -9,7 +9,7 @@ import (
 // SynonymSetInterface is a type for individual Synonym Set API operations
 type SynonymSetInterface interface {
 	// Retrieve a single synonym set
-	Retrieve(ctx context.Context) (*api.SynonymSetRetrieveSchema, error)
+	Retrieve(ctx context.Context) (*api.SynonymSetSchema, error)
 	// Update a synonym set
 	Upsert(ctx context.Context, synonymSetSchema *api.SynonymSetCreateSchema) (*api.SynonymSetSchema, error)
 	// Delete a synonym set
@@ -22,7 +22,7 @@ type synonymSet struct {
 	synonymSetName string
 }
 
-func (s *synonymSet) Retrieve(ctx context.Context) (*api.SynonymSetRetrieveSchema, error) {
+func (s *synonymSet) Retrieve(ctx context.Context) (*api.SynonymSetSchema, error) {
 	response, err := s.apiClient.RetrieveSynonymSetWithResponse(ctx, s.synonymSetName)
 	if err != nil {
 		return nil, err

--- a/typesense/test/analytics_rule_test.go
+++ b/typesense/test/analytics_rule_test.go
@@ -18,7 +18,7 @@ func analyticsRuleCleanUp() {
 	for _, rule := range result {
 		typesenseClient.Analytics().Rule(rule.Name).Delete(context.Background())
 	}
-	
+
 	// Clean up collections
 	collections, _ := typesenseClient.Collections().Retrieve(context.Background(), nil)
 	for _, collection := range collections {
@@ -32,12 +32,12 @@ func TestAnalyticsRule(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		collectionName := createNewCollection(t, "analytics-rules-collection")
-		
+
 		// Create the rule directly using the Create API
 		ruleName := newUUIDName("test-rule")
 		ruleCreate := &api.AnalyticsRuleCreate{
 			Name:       ruleName,
-			Type:       api.AnalyticsRuleCreateTypeCounter,
+			Type:       api.Counter,
 			Collection: collectionName,
 			EventType:  "click",
 			Params: &api.AnalyticsRuleCreateParams{
@@ -49,10 +49,10 @@ func TestAnalyticsRule(t *testing.T) {
 		result, err := typesenseClient.Analytics().Rules().Create(context.Background(), []*api.AnalyticsRuleCreate{ruleCreate})
 		require.NoError(t, err)
 		require.Len(t, result, 1)
-		
+
 		createdRule := result[0]
 		require.Equal(t, ruleName, createdRule.Name)
-		require.Equal(t, api.AnalyticsRuleTypeCounter, createdRule.Type)
+		require.Equal(t, api.Counter, createdRule.Type)
 		require.Equal(t, collectionName, createdRule.Collection)
 		require.Equal(t, "click", createdRule.EventType)
 	})

--- a/typesense/test/dbhelpers_test.go
+++ b/typesense/test/dbhelpers_test.go
@@ -299,8 +299,6 @@ func newKey() *api.ApiKey {
 	}
 }
 
-
-
 func newCurationSetCreateSchema() *api.CurationSetCreateSchema {
 	return &api.CurationSetCreateSchema{
 		Items: []api.CurationItemCreateSchema{
@@ -452,7 +450,7 @@ func newPresetFromMultiSearchSearchesParameter(presetName string) *api.PresetSch
 func newAnalyticsRule(ruleName string, collectionName string, sourceCollectionName string, eventName string) *api.AnalyticsRule {
 	return &api.AnalyticsRule{
 		Name:       ruleName,
-		Type:       api.AnalyticsRuleTypeCounter,
+		Type:       api.Counter,
 		Collection: collectionName,
 		EventType:  "click",
 		Params: &api.AnalyticsRuleCreateParams{
@@ -469,7 +467,7 @@ func createNewAnalyticsRule(t *testing.T, collectionName string, sourceCollectio
 	// Create the rule using the new API
 	ruleCreate := &api.AnalyticsRuleCreate{
 		Name:       ruleName,
-		Type:       api.AnalyticsRuleCreateTypeCounter,
+		Type:       api.Counter,
 		Collection: collectionName,
 		EventType:  "click",
 		Params: &api.AnalyticsRuleCreateParams{


### PR DESCRIPTION
## Change Summary
This PR adds support for asynchronous reference fields in the Typesense Go SDK. The async_reference field option allows documents to be indexed successfully even when the referenced document doesn't exist yet.

https://typesense.org/docs/29.0/api/joins.html#asynchronous-references

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).