### PR TITLE
fix(config): merge defaults for nils when adding a custom config

### DIFF
--- a/typesense/api/types.go
+++ b/typesense/api/types.go
@@ -1,3 +1,4 @@
+//nolint:revive // package name is part of the public API surface.
 package api
 
 type ImportDocumentResponse struct {

--- a/typesense/client.go
+++ b/typesense/client.go
@@ -285,23 +285,59 @@ func WithCircuitBreakerOnStateChange(onStateChange circuit.GoBreakerOnStateChang
 	}
 }
 
-// WithClientConfig allows to pass all configs at once
+// WithClientConfig allows passing multiple configs at once.
+// Zero-value fields are ignored so NewClient defaults remain effective
+// when callers provide only a partial config.
 func WithClientConfig(config *ClientConfig) ClientOption {
 	return func(c *Client) {
-		c.apiConfig.ServerURL = config.ServerURL
-		c.apiConfig.NearestNode = config.NearestNode
-		c.apiConfig.Nodes = config.Nodes
-		c.apiConfig.NumRetries = config.NumRetries
-		c.apiConfig.RetryInterval = config.RetryInterval
-		c.apiConfig.HealthcheckInterval = config.HealthcheckInterval
-		c.apiConfig.APIKey = config.APIKey
-		c.apiConfig.ConnectionTimeout = config.ConnectionTimeout
-		c.apiConfig.CircuitBreakerName = config.CircuitBreakerName
-		c.apiConfig.CircuitBreakerMaxRequests = config.CircuitBreakerMaxRequests
-		c.apiConfig.CircuitBreakerInterval = config.CircuitBreakerInterval
-		c.apiConfig.CircuitBreakerTimeout = config.CircuitBreakerTimeout
-		c.apiConfig.CircuitBreakerReadyToTrip = config.CircuitBreakerReadyToTrip
-		c.apiConfig.CircuitBreakerOnStateChange = config.CircuitBreakerOnStateChange
+		if config == nil {
+			return
+		}
+		if config.ServerURL != "" {
+			c.apiConfig.ServerURL = config.ServerURL
+		}
+		if config.NearestNode != "" {
+			c.apiConfig.NearestNode = config.NearestNode
+		}
+		if config.Nodes != nil {
+			c.apiConfig.Nodes = config.Nodes
+		}
+		if config.NumRetries >= 0 {
+			c.apiConfig.NumRetries = config.NumRetries
+		}
+		if config.RetryInterval > 0 {
+			c.apiConfig.RetryInterval = config.RetryInterval
+		}
+		if config.HealthcheckInterval > 0 {
+			c.apiConfig.HealthcheckInterval = config.HealthcheckInterval
+		}
+		if config.APIKey != "" {
+			c.apiConfig.APIKey = config.APIKey
+		}
+		if config.ConnectionTimeout > 0 {
+			c.apiConfig.ConnectionTimeout = config.ConnectionTimeout
+		}
+		if config.CircuitBreakerName != "" {
+			c.apiConfig.CircuitBreakerName = config.CircuitBreakerName
+		}
+		if config.CircuitBreakerMaxRequests > 0 {
+			c.apiConfig.CircuitBreakerMaxRequests = config.CircuitBreakerMaxRequests
+		}
+		if config.CircuitBreakerInterval > 0 {
+			c.apiConfig.CircuitBreakerInterval = config.CircuitBreakerInterval
+		}
+		if config.CircuitBreakerTimeout > 0 {
+			c.apiConfig.CircuitBreakerTimeout = config.CircuitBreakerTimeout
+		}
+		if config.CircuitBreakerReadyToTrip != nil {
+			c.apiConfig.CircuitBreakerReadyToTrip = config.CircuitBreakerReadyToTrip
+		}
+		if config.CircuitBreakerOnStateChange != nil {
+			c.apiConfig.CircuitBreakerOnStateChange = config.CircuitBreakerOnStateChange
+		}
+		if config.CustomHTTPClient != nil {
+			c.apiConfig.CustomHTTPClient = config.CustomHTTPClient
+		}
 	}
 }
 

--- a/typesense/client_test.go
+++ b/typesense/client_test.go
@@ -240,6 +240,51 @@ func TestClientConfigOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "WithConfigPartialKeepsDefaults",
+			options: []ClientOption{
+				WithClientConfig(&ClientConfig{
+					ServerURL: "http://example.com",
+					APIKey:    "API_KEY_1",
+				}),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, "http://example.com", client.apiConfig.ServerURL)
+				assert.Equal(t, "API_KEY_1", client.apiConfig.APIKey)
+				assert.Equal(t, defaultRetryInterval, client.apiConfig.RetryInterval)
+				assert.Equal(t, defaultHealthcheckInterval, client.apiConfig.HealthcheckInterval)
+				assert.Equal(t, defaultConnectionTimeout, client.apiConfig.ConnectionTimeout)
+				assert.Equal(t, defaultCircuitBreakerName, client.apiConfig.CircuitBreakerName)
+				assert.Equal(t, circuit.DefaultGoBreakerMaxRequests, client.apiConfig.CircuitBreakerMaxRequests)
+				assert.Equal(t, circuit.DefaultGoBreakerInterval, client.apiConfig.CircuitBreakerInterval)
+				assert.Equal(t, circuit.DefaultGoBreakerTimeout, client.apiConfig.CircuitBreakerTimeout)
+				assert.Equal(t,
+					reflect.ValueOf(circuit.DefaultReadyToTrip).Pointer(),
+					reflect.ValueOf(client.apiConfig.CircuitBreakerReadyToTrip).Pointer(),
+					"readyToTrip is not valid")
+				assert.NotNil(t, client.apiClient)
+			},
+		},
+		{
+			name: "WithNilConfig",
+			options: []ClientOption{
+				WithClientConfig(nil),
+			},
+			verify: func(t *testing.T, client *Client) {
+				assert.Equal(t, defaultRetryInterval, client.apiConfig.RetryInterval)
+				assert.Equal(t, defaultHealthcheckInterval, client.apiConfig.HealthcheckInterval)
+				assert.Equal(t, defaultConnectionTimeout, client.apiConfig.ConnectionTimeout)
+				assert.Equal(t, defaultCircuitBreakerName, client.apiConfig.CircuitBreakerName)
+				assert.Equal(t, circuit.DefaultGoBreakerMaxRequests, client.apiConfig.CircuitBreakerMaxRequests)
+				assert.Equal(t, circuit.DefaultGoBreakerInterval, client.apiConfig.CircuitBreakerInterval)
+				assert.Equal(t, circuit.DefaultGoBreakerTimeout, client.apiConfig.CircuitBreakerTimeout)
+				assert.Equal(t,
+					reflect.ValueOf(circuit.DefaultReadyToTrip).Pointer(),
+					reflect.ValueOf(client.apiConfig.CircuitBreakerReadyToTrip).Pointer(),
+					"readyToTrip is not valid")
+				assert.NotNil(t, client.apiClient)
+			},
+		},
+		{
 			name: "WithCustomHTTPClient",
 			options: []ClientOption{
 				WithCustomHTTPClient(&http.Client{


### PR DESCRIPTION
## Change Summary
fix #220 to have client creation have the same behavior as the rest of the client libraries.